### PR TITLE
Add executable script for dependency usage

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,9 @@ targets:
   cyclonedx-cr:
     main: src/main.cr
 
+executables:
+  - cyclonedx-cr.cr
+
 crystal: 1.6.2
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,7 @@ targets:
     main: src/main.cr
 
 executables:
-  - cyclonedx-cr.cr
+  - cyclonedx-cr
 
 crystal: 1.6.2
 


### PR DESCRIPTION
Adds `bin/cyclonedx-cr.cr` and registers it in `shard.yml` to allow usage as a dependency executable.

---
*PR created automatically by Jules for task [2509948208486828402](https://jules.google.com/task/2509948208486828402) started by @hahwul*