### PR TITLE
Refactor `App#run` to exit with error code on validation failure

### DIFF
--- a/src/app.cr
+++ b/src/app.cr
@@ -32,8 +32,8 @@ class App
   # Runs the main application logic.
   def run
     options = parse_options
-    return unless validate_options(options)
-    return unless validate_input_files(options)
+    exit(1) unless validate_options(options)
+    exit(1) unless validate_input_files(options)
 
     bom = generate_bom(options)
     write_output(bom, options)


### PR DESCRIPTION
Modified `src/app.cr` to exit with status code 1 when validation fails, instead of just returning. This improves error handling in CLI usage. Verified with manual tests and existing specs.

---
*PR created automatically by Jules for task [6164284652603929799](https://jules.google.com/task/6164284652603929799) started by @hahwul*