### PR TITLE
Consistent BOM Serial Number Handling

### DIFF
--- a/spec/cyclonedx/bom_spec.cr
+++ b/spec/cyclonedx/bom_spec.cr
@@ -1,0 +1,46 @@
+require "spec"
+require "../../src/cyclonedx/bom"
+require "uuid"
+
+describe CycloneDX::BOM do
+  describe "serialNumber consistency" do
+    it "has a consistent serial number across XML generations" do
+      components = [] of CycloneDX::Component
+      bom = CycloneDX::BOM.new(components, "1.4")
+
+      xml1 = bom.to_xml
+      xml2 = bom.to_xml
+
+      match1 = xml1.match(/serialNumber="([^"]+)"/)
+      match2 = xml2.match(/serialNumber="([^"]+)"/)
+
+      match1.should_not be_nil
+      match2.should_not be_nil
+
+      if match1 && match2
+        # This is expected to fail before the fix
+        match1[1].should eq(match2[1])
+        match1[1].should start_with("urn:uuid:")
+      end
+    end
+
+    it "includes serialNumber in JSON output matching the object state" do
+      components = [] of CycloneDX::Component
+      bom = CycloneDX::BOM.new(components, "1.4")
+
+      # Generate XML to potentially trigger lazy initialization if it were implemented that way (it's not, but good practice)
+      xml = bom.to_xml
+      match_xml = xml.match(/serialNumber="([^"]+)"/)
+      match_xml.should_not be_nil
+
+      # Check JSON
+      json = bom.to_json
+      # This is expected to fail before the fix as serialNumber is missing
+      json.should contain("serialNumber")
+
+      if match_xml
+        json.should contain(match_xml[1])
+      end
+    end
+  end
+end

--- a/src/cyclonedx/bom.cr
+++ b/src/cyclonedx/bom.cr
@@ -27,6 +27,10 @@ class CycloneDX::BOM
   @[JSON::Field(key: "version")]
   getter bom_version : Int32 = BOM_VERSION
 
+  # The unique serial number of the BOM.
+  @[JSON::Field(key: "serialNumber")]
+  getter serial_number : String = "urn:uuid:#{UUID.random}"
+
   # Metadata about the BOM.
   getter metadata : Metadata?
 
@@ -51,7 +55,7 @@ class CycloneDX::BOM
         xml.element("bom", attributes: {
           "xmlns":        "#{XML_NAMESPACE}/#{@spec_version}",
           "version":      BOM_VERSION.to_s,
-          "serialNumber": "urn:uuid:#{UUID.random}",
+          "serialNumber": @serial_number,
         }) do
           @metadata.try(&.to_xml(xml))
           xml.element("components") do


### PR DESCRIPTION
This change addresses the code health issue of inconsistent serial number handling in BOM generation.

### Changes
- Added `@serial_number` instance variable to `CycloneDX::BOM`, initialized to a random UUID string.
- Updated `to_xml` method to use this instance variable instead of generating a new UUID on each call.
- Annotated `@serial_number` with `@[JSON::Field(key: "serialNumber")]` to include it in the JSON output, which was previously missing.
- Added `spec/cyclonedx/bom_spec.cr` to test that the serial number is consistent across XML generations and present in JSON output.

### Verification
- Ran `crystal spec spec/cyclonedx/bom_spec.cr` to verify the fix and new tests.
- Ran `crystal spec` to ensure no regressions in existing tests.
- Manually verified JSON output in test logs contains `serialNumber`.

---
*PR created automatically by Jules for task [15332533569514534584](https://jules.google.com/task/15332533569514534584) started by @hahwul*