### PR TITLE
Handle file read and parse exceptions gracefully

### DIFF
--- a/src/app.cr
+++ b/src/app.cr
@@ -141,7 +141,17 @@ class App
   # @param file_path [String] The path to the `shard.yml` file.
   # @return [CycloneDX::Component] The main application component.
   private def parse_main_component(file_path : String) : CycloneDX::Component
-    shard = ShardFile.from_yaml(File.read(file_path))
+    begin
+      shard = ShardFile.from_yaml(File.read(file_path))
+    rescue ex : YAML::ParseException
+      STDERR.puts "Error: Failed to parse `#{file_path}`. Please ensure the file contains valid YAML."
+      STDERR.puts ex.message
+      exit(1)
+    rescue ex : File::Error
+      STDERR.puts "Error: Could not read `#{file_path}`."
+      STDERR.puts ex.message
+      exit(1)
+    end
 
     licenses = [] of CycloneDX::License
     if license_name = shard.license
@@ -174,7 +184,18 @@ class App
   # @param file_path [String] The path to the `shard.lock` file.
   # @return [Array(CycloneDX::Component)] An array of dependency components.
   private def parse_dependencies(file_path : String) : Array(CycloneDX::Component)
-    lock_file = ShardLockFile.from_yaml(File.read(file_path))
+    begin
+      lock_file = ShardLockFile.from_yaml(File.read(file_path))
+    rescue ex : YAML::ParseException
+      STDERR.puts "Error: Failed to parse `#{file_path}`. Please ensure the file contains valid YAML."
+      STDERR.puts ex.message
+      exit(1)
+    rescue ex : File::Error
+      STDERR.puts "Error: Could not read `#{file_path}`."
+      STDERR.puts ex.message
+      exit(1)
+    end
+
     lock_file.shards.map do |name, details|
       CycloneDX::Component.new(
         name: name,


### PR DESCRIPTION
This change improves the code health of `src/app.cr` by adding exception handling for file operations. Previously, missing files or invalid YAML would cause the application to crash with a stack trace. Now, it prints a descriptive error message and exits cleanly. This was applied to both `shard.yml` parsing in `parse_main_component` and `shard.lock` parsing in `parse_dependencies`.

I verified the changes by:
1. Running `shards build` to ensure compilation success.
2. Running the tool against a file with invalid YAML and confirming the friendly error message.
3. Running the tool against a file with no read permissions and confirming the friendly error message.
4. Running the tool against valid files and confirming it still produces the correct SBOM.
5. Running `crystal spec` to ensure no regressions in existing tests.

---
*PR created automatically by Jules for task [14455827752180071418](https://jules.google.com/task/14455827752180071418) started by @hahwul*