### PR TITLE
Fix version mismatch, harden entrypoint, and improve error handling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
     default: ""
   spec_version:
-    description: "CycloneDX spec version (options: 1.4, 1.5, 1.6)"
+    description: "CycloneDX spec version (options: 1.4, 1.5, 1.6, 1.7)"
     required: false
     default: "1.6"
   output_format:

--- a/github-action/entrypoint.sh
+++ b/github-action/entrypoint.sh
@@ -30,23 +30,21 @@ else
     exit 1
 fi
 
-# Build the cyclonedx-cr command
-cmd="$CYCLONEDX_BIN -s $SHARD_FILE -i $LOCK_FILE --spec-version $SPEC_VERSION --output-format $OUTPUT_FORMAT"
-
 # Handle output file
 if [ -n "$OUTPUT_FILE" ]; then
-    cmd="$cmd -o $OUTPUT_FILE"
     OUTPUT_TO_FILE=true
 else
-    OUTPUT_FILE="/tmp/sbom_output"
-    cmd="$cmd -o $OUTPUT_FILE"
+    OUTPUT_FILE=$(mktemp)
     OUTPUT_TO_FILE=false
 fi
 
-echo "Executing command: $cmd"
+# Cleanup temp file on exit
+if [ "$OUTPUT_TO_FILE" = "false" ]; then
+    trap "rm -f '$OUTPUT_FILE'" EXIT
+fi
 
 # Execute the command
-if ! eval "$cmd"; then
+if ! "$CYCLONEDX_BIN" -s "$SHARD_FILE" -i "$LOCK_FILE" --spec-version "$SPEC_VERSION" --output-format "$OUTPUT_FORMAT" -o "$OUTPUT_FILE"; then
     echo "Error: cyclonedx-cr command failed"
     exit 1
 fi
@@ -58,17 +56,19 @@ if [ ! -f "$OUTPUT_FILE" ]; then
 fi
 
 # Set GitHub Action outputs
-if [ "$OUTPUT_TO_FILE" = "true" ]; then
-    echo "sbom_file=$OUTPUT_FILE" >> "$GITHUB_OUTPUT"
-    echo "Generated SBOM file: $OUTPUT_FILE"
-else
-    # Use heredoc for multiline output to avoid delimiter issues
-    {
-        echo "sbom_content<<EOF"
-        cat "$OUTPUT_FILE"
-        echo "EOF"
-    } >> "$GITHUB_OUTPUT"
-    echo "Generated SBOM content (captured to output)"
+if [ -n "$GITHUB_OUTPUT" ]; then
+    if [ "$OUTPUT_TO_FILE" = "true" ]; then
+        echo "sbom_file=$OUTPUT_FILE" >> "$GITHUB_OUTPUT"
+        echo "Generated SBOM file: $OUTPUT_FILE"
+    else
+        # Use heredoc for multiline output to avoid delimiter issues
+        {
+            echo "sbom_content<<EOF"
+            cat "$OUTPUT_FILE"
+            echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+        echo "Generated SBOM content (captured to output)"
+    fi
 fi
 
 echo "cyclonedx-cr GitHub Action completed successfully"

--- a/src/app.cr
+++ b/src/app.cr
@@ -9,7 +9,7 @@ require "./shard/shard_lock_file"
 # Main application class for generating CycloneDX SBOMs from Crystal Shard files.
 # Handles command-line argument parsing, file reading, and SBOM generation.
 class App
-  VERSION            = "1.0.2"
+  VERSION            = "1.1.0"
   SUPPORTED_VERSIONS = ["1.4", "1.5", "1.6", "1.7"]
   SUPPORTED_FORMATS  = ["json", "xml", "csv"]
   DEFAULT_VERSION    = "1.6"
@@ -25,9 +25,8 @@ class App
   SCOPE_REQUIRED = "required"
   SCOPE_OPTIONAL = "optional"
 
-  # Regex patterns for parsing Git URLs
-  private GITHUB_URL_PATTERN = /.*github\.com[\/:]/
-  private GIT_SUFFIX_PATTERN = /\.git$/
+  # Regex pattern for extracting owner/repo from GitHub Git URLs
+  private GITHUB_REPO_PATTERN = /github\.com[\/:]([^\/]+\/[^\/]+?)(?:\.git)?$/
 
   # Holds parsed command-line options.
   record Options,
@@ -136,8 +135,14 @@ class App
     if options.output_file.empty?
       puts output_content
     else
-      File.write(options.output_file, output_content)
-      STDERR.puts "SBOM successfully written to #{options.output_file} in #{options.output_format.upcase} format."
+      begin
+        File.write(options.output_file, output_content)
+        STDERR.puts "SBOM successfully written to #{options.output_file} in #{options.output_format.upcase} format."
+      rescue ex : File::Error
+        STDERR.puts "Error: Could not write to `#{options.output_file}`."
+        STDERR.puts ex.message
+        exit(1)
+      end
     end
   end
 
@@ -244,9 +249,10 @@ class App
     end
   end
 
-  # Extracts the GitHub repository path from a Git URL.
+  # Extracts the GitHub repository path (owner/repo) from a Git URL.
   private def parse_github_repo_from_git_url(git_url : String) : String?
-    return unless git_url.includes?("github.com")
-    git_url.sub(GITHUB_URL_PATTERN, "").sub(GIT_SUFFIX_PATTERN, "")
+    if git_url =~ GITHUB_REPO_PATTERN
+      $1
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Sync `VERSION` constant in `app.cr` with `shard.yml` (`1.0.2` → `1.1.0`)
- Add `File::Error` rescue in `write_output` for graceful file write failure handling
- Remove `eval` usage in `entrypoint.sh` to prevent shell injection, use direct command execution
- Replace fixed `/tmp/sbom_output` path with `mktemp` and add `trap` cleanup
- Guard `GITHUB_OUTPUT` writes with existence check
- Improve PURL regex to use single capture group for accurate `owner/repo` extraction
- Add spec version `1.7` to `action.yml` documentation to match supported versions

## Test plan
- [x] `crystal spec` — 65 examples, 0 failures
- [x] `ameba` lint — 8 files inspected, 0 failures