### PR TITLE
Add executables field for shards install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ brew install hahwul/cyclonedx-cr/cyclonedx-cr
 docker run --rm -v $(pwd):/workspace -w /workspace ghcr.io/hahwul/cyclonedx-cr:latest
 ```
 
+### As a Shard Dependency
+
+Add cyclonedx-cr to your `shard.yml`:
+
+```yaml
+development_dependencies:
+  cyclonedx-cr:
+    github: hahwul/cyclonedx-cr
+```
+
+Then run:
+
+```bash
+shards install
+bin/cyclonedx-cr
+```
+
 ### From Source
 
 Requirements: [Crystal](https://crystal-lang.org/) 1.6.2+

--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,9 @@ targets:
   cyclonedx-cr:
     main: src/main.cr
 
+executables:
+  - cyclonedx-cr
+
 crystal: 1.6.2
 
 license: MIT


### PR DESCRIPTION
## Summary
- Add `executables` field to `shard.yml` so that other Crystal projects can use cyclonedx-cr as a dependency and get `bin/cyclonedx-cr` automatically built via `shards install`

## Example usage
```yaml
development_dependencies:
  cyclonedx-cr:
    github: hahwul/cyclonedx-cr
```

After `shards install`, `bin/cyclonedx-cr` will be available.

## Test plan
- [ ] Add cyclonedx-cr as a dependency in another Crystal project and verify `bin/cyclonedx-cr` is created after `shards install`