### PR TITLE
Add executable entrypoints for shards install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Crystal
-bin
+bin/*
+!bin/cyclonedx-cr
 lib
 
 # SBOM

--- a/bin/cyclonedx-cr
+++ b/bin/cyclonedx-cr
@@ -1,0 +1,4 @@
+#!/usr/bin/env crystal
+require "cyclonedx-cr"
+
+App.new.run

--- a/src/cyclonedx-cr.cr
+++ b/src/cyclonedx-cr.cr
@@ -1,0 +1,1 @@
+require "./app"


### PR DESCRIPTION
## Summary
- Add `bin/cyclonedx-cr` executable entrypoint and `src/cyclonedx-cr.cr` library entrypoint so the `executables` field in shard.yml works correctly
- Update `.gitignore` to track `bin/cyclonedx-cr` while still ignoring compiled binaries

## Context
Follow-up to #43. The `executables` field alone wasn't enough — shards needs a source file in `bin/` to copy into the consuming project, and a library entrypoint at `src/cyclonedx-cr.cr` for the `require "cyclonedx-cr"` to resolve.

## Tested
```
$ shards install
I: Installing cyclonedx-cr (1.1.0)

$ bin/cyclonedx-cr -h
Usage: cyclonedx-cr [arguments]
    -i FILE, --input=FILE            shard.lock file path (default: shard.lock)
    ...

$ bin/cyclonedx-cr
{"bomFormat":"CycloneDX","specVersion":"1.6",...}
```