### PR TITLE
chore: switch to official crystallang/crystal image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     container:
-      image: 84codes/crystal:latest-debian-12
+      image: crystallang/crystal:1.19.1
     steps:
       - uses: actions/checkout@v6
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ##= BUILDER =##
-FROM 84codes/crystal:latest-debian-12 AS builder
+FROM crystallang/crystal:1.19.1 AS builder
 
 WORKDIR /cyclonedx-cr
 
@@ -20,14 +20,14 @@ RUN shards build --release --no-debug --production && \
     strip bin/cyclonedx-cr
 
 ##= RUNNER =##
-# Use Debian 12 runtime to match builder's ABI (avoids ICU/glibc mismatches)
-FROM debian:12-slim
+# Match builder's ABI (Ubuntu 24.04) to avoid ICU/glibc mismatches
+FROM ubuntu:24.04
 
 # Install runtime libraries required by the linked binary
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libyaml-0-2 \
     libxml2 \
-    libicu72 \
+    libicu74 \
     libpcre2-8-0 \
     libgc1 \
     liblzma5 \


### PR DESCRIPTION
## Summary
- Crystal now provides [official Linux ARM64 builds](https://crystal-lang.org/2026/04/07/official-linux-arm64-builds/), so we can drop the 84codes images that were previously needed for multi-arch coverage.
- Builder + CI test container: `84codes/crystal:latest-debian-12` → `crystallang/crystal:1.19.1`
- The official image is Ubuntu 24.04-based, so the runner base also moves from `debian:12-slim` to `ubuntu:24.04` to keep ICU/glibc ABI in sync (`libicu72` → `libicu74`).

## Test plan
- [x] `docker build .` succeeds locally; `cyclonedx-cr --help` runs in the resulting image
- [x] CI green (build-crystal matrix, build-docker for amd64/arm64, tests)