### PR TITLE
feat: add Crystal 1.20 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crystal-version: [1.10.1, 1.15.0, 1.19.0]
+        crystal-version: [1.10.1, 1.15.0, 1.19.0, 1.20.0]
     steps:
       - uses: actions/checkout@v6
       - uses: crystal-lang/install-crystal@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ##= BUILDER =##
-FROM crystallang/crystal:1.19.1 AS builder
+FROM crystallang/crystal:1.20.0 AS builder
 
 WORKDIR /cyclonedx-cr
 


### PR DESCRIPTION
Crystal 1.20 has been released. This PR adds Crystal 1.20 to the CI matrix and updates deployment configurations.