### PR TITLE
security: run image and Action as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=builder /cyclonedx-cr/bin/cyclonedx-cr /usr/local/bin/cyclonedx-cr
 
-# Run as non-root
-# USER 2:2
+# Run as a non-root user. uid/gid 1001 matches the default uid of the
+# GitHub Actions runner, which means SBOM output written to a bind-mounted
+# $GITHUB_WORKSPACE will land owned by the runner user instead of root.
+# Standalone CLI consumers can override with `--user` if needed.
+RUN groupadd --system --gid 1001 cyclonedx \
+ && useradd  --system --uid 1001 --gid cyclonedx --create-home --shell /usr/sbin/nologin cyclonedx
+USER 1001:1001
 
 # Default command
 CMD ["cyclonedx-cr"]

--- a/github-action/Dockerfile
+++ b/github-action/Dockerfile
@@ -6,5 +6,16 @@ COPY entrypoint.sh /entrypoint.sh
 
 # Run the script via /bin/sh, so no executable bit is required
 
+# Run as a non-root user so SBOM output written into the bind-mounted
+# $GITHUB_WORKSPACE is owned by the runner user instead of root. The
+# `id -u cyclonedx` check makes this work whether the base image already
+# provisions the user (newer releases) or not (v1.3.0 and earlier).
+USER root
+RUN if ! id -u cyclonedx >/dev/null 2>&1; then \
+      groupadd --system --gid 1001 cyclonedx && \
+      useradd  --system --uid 1001 --gid cyclonedx --create-home --shell /usr/sbin/nologin cyclonedx; \
+    fi
+USER 1001:1001
+
 # Set the entrypoint to the script
 ENTRYPOINT ["/bin/sh", "-l", "/entrypoint.sh"]


### PR DESCRIPTION
## Summary

The base `Dockerfile` shipped with `USER 2:2` commented out and `github-action/Dockerfile` inherited that, so `cyclonedx-cr` ran as root inside the container. In a GitHub Action context the runner bind-mounts `\$GITHUB_WORKSPACE` into the container, so SBOM output written by the action ended up owned by root on the host runner — defeating any later chown/cleanup that assumed runner ownership and giving the action more write authority than it needs.

### Finding addressed
- **Medium** — `Dockerfile:41` and `github-action/Dockerfile` ran as root; output files end up root-owned on the runner.

## Changes

- Base `Dockerfile`: provision a system user (uid/gid 1001, matching the GitHub runner default) and switch to it via `USER 1001:1001`. uid 1001 means files written into a bind-mounted `\$GITHUB_WORKSPACE` land owned by the runner user instead of root.
- `github-action/Dockerfile`: defensively create the user if the inherited base image (still pinned to `v1.3.0`) doesn't have it yet, then `USER 1001:1001`. This makes the fix effective immediately on merge instead of waiting for a base-image release.

The `cyclonedx-cr` binary doesn't need privileged operations — only read access to `shard.yml`/`shard.lock` and write access to the output path.

## Test plan
- [ ] `docker build` of both Dockerfiles succeeds
- [ ] Local container produces an SBOM owned by uid 1001 when bind-mounted
- [ ] GitHub Action workflow run succeeds end-to-end with the new image (will be exercised on merge by existing CI)