### PR TITLE
improve: emit CycloneDX LicenseChoice + SPDX ids, sync App::VERSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- License entries now follow the CycloneDX `LicenseChoice` shape:
+  `{"license": {...}}` instead of a flat `{"id":"...","name":"..."}`.
+  XML output already used `<license>...</license>` so this is a JSON-only
+  fix that aligns with the 1.4–1.7 schemas.
+
+### Changed
+- License identifiers that exist in the SPDX license list are now emitted
+  as the canonical SPDX `id` (e.g. `{"license":{"id":"MIT"}}`). Free-form
+  values that are not in the SPDX list still fall through to `name`.
+  Backed by a new dependency on `spdx.cr`.
+
 ## v1.3.0
 
 ### Added

--- a/justfile
+++ b/justfile
@@ -22,6 +22,7 @@ version-check:
     "README.md"
     "github-action/Dockerfile"
     ".github/workflows/release-sbom.yml"
+    "src/app.cr"
   )
   ok=true
   for file in "${files[@]}"; do
@@ -60,6 +61,8 @@ version-update new_version:
   echo "  [UPDATED] github-action/Dockerfile"
   sed -i '' "s|cyclonedx-cr@v$old_version|cyclonedx-cr@v$new_version|g" .github/workflows/release-sbom.yml
   echo "  [UPDATED] .github/workflows/release-sbom.yml"
+  sed -i '' "s|VERSION            = \"$old_version\"|VERSION            = \"$new_version\"|" src/app.cr
+  echo "  [UPDATED] src/app.cr"
   echo ""
   echo "Done! Run 'just version-check' to verify."
 

--- a/shard.lock
+++ b/shard.lock
@@ -4,3 +4,7 @@ shards:
     git: https://github.com/crystal-ameba/ameba.git
     version: 1.7.0-dev+git.commit.f5d1ef6b995a6c103267dd779426f83e0b25aa8c
 
+  spdx:
+    git: https://github.com/hahwul/spdx.cr.git
+    version: 0.1.0+git.commit.21ac950936830412628cbf631bf48ece6dce9a48
+

--- a/shard.yml
+++ b/shard.yml
@@ -19,6 +19,10 @@ crystal: ">= 1.6.2"
 
 license: MIT
 
+dependencies:
+  spdx:
+    github: hahwul/spdx.cr
+
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba

--- a/spec/app_integration_spec.cr
+++ b/spec/app_integration_spec.cr
@@ -66,12 +66,14 @@ describe "App Integration" do
       component["author"].should eq("Test Author <test@example.com>")
     end
 
-    it "includes licenses from shard.yml" do
+    it "includes licenses from shard.yml as a wrapped SPDX id" do
+      # MIT is in the SPDX license list, so it should serialize as
+      # `{"license":{"id":"MIT"}}` per CycloneDX 1.6 LicenseChoice.
       output = `#{BINARY} -s #{FIXTURES}/shard.yml -i #{FIXTURES}/shard.lock 2>&1`
       component = JSON.parse(output)["metadata"]["component"]
       licenses = component["licenses"].as_a
       licenses.size.should eq(1)
-      licenses[0]["name"].should eq("MIT")
+      licenses[0]["license"]["id"].should eq("MIT")
     end
 
     it "includes dependencies as components" do
@@ -220,10 +222,23 @@ describe "App Integration" do
       output.should contain("<expression>MIT OR Apache-2.0</expression>")
     end
 
-    it "uses license name for simple licenses" do
+    it "uses the SPDX id (not name) for licenses present in the SPDX list" do
+      # SPDX recognizes "MIT", so we emit the canonical id field rather
+      # than the free-form name field.
       output = `#{BINARY} -s #{FIXTURES}/shard.yml -i #{FIXTURES}/shard.lock 2>&1`
       component = JSON.parse(output)["metadata"]["component"]
-      component["licenses"].as_a[0]["name"].should eq("MIT")
+      license = component["licenses"].as_a[0]["license"]
+      license["id"].should eq("MIT")
+      license["name"]?.should be_nil
+    end
+
+    it "falls back to license name for identifiers not in the SPDX list" do
+      output = `#{BINARY} -s #{FIXTURES}/custom_license_shard.yml -i #{FIXTURES}/empty_lock.lock 2>&1`
+      $?.success?.should be_true
+      component = JSON.parse(output)["metadata"]["component"]
+      license = component["licenses"].as_a[0]["license"]
+      license["name"].should eq("Proprietary")
+      license["id"]?.should be_nil
     end
   end
 end

--- a/spec/cyclonedx/models_spec.cr
+++ b/spec/cyclonedx/models_spec.cr
@@ -37,31 +37,34 @@ describe CycloneDX::License do
   end
 
   describe "#to_json" do
-    it "serializes to JSON correctly with id" do
+    # CycloneDX 1.6 LicenseChoice wraps the license object as
+    # `{"license": {...}}`, and within that object `id` and `name` are
+    # mutually exclusive (`id` is preferred when both are set).
+    it "wraps the license object as {\"license\":{...}}" do
       license = CycloneDX::License.new(id: "MIT")
       json = license.to_json
-      json.should contain(%("id":"MIT"))
-      json.should_not contain(%("name"))
+      json.should eq(%({"license":{"id":"MIT"}}))
     end
 
-    it "serializes to JSON correctly with name" do
+    it "uses name when id is not present" do
       license = CycloneDX::License.new(name: "My License")
       json = license.to_json
       json.should contain(%("name":"My License"))
       json.should_not contain(%("id"))
     end
 
-    it "serializes to JSON correctly with both" do
+    it "prefers id over name (LicenseChoice does not allow both)" do
       license = CycloneDX::License.new(id: "MIT", name: "MIT License")
       json = license.to_json
       json.should contain(%("id":"MIT"))
-      json.should contain(%("name":"MIT License"))
+      json.should_not contain(%("name"))
     end
 
-    it "serializes url to JSON" do
+    it "serializes url alongside id inside the wrapper" do
       license = CycloneDX::License.new(id: "MIT", url: "https://opensource.org/licenses/MIT")
       json = license.to_json
       json.should contain(%("url":"https://opensource.org/licenses/MIT"))
+      json.should match(/\A\{"license":\{/)
     end
   end
 

--- a/spec/fixtures/custom_license_shard.yml
+++ b/spec/fixtures/custom_license_shard.yml
@@ -1,0 +1,7 @@
+name: custom-license-app
+version: 0.1.0
+
+authors:
+  - Test Author <test@example.com>
+
+license: Proprietary

--- a/spec/main_spec.cr
+++ b/spec/main_spec.cr
@@ -10,6 +10,15 @@ describe App do
     # For now, we'll just check that the App class can be instantiated.
     app.should_not be_nil
   end
+
+  it "advertises a VERSION matching shard.yml" do
+    shard_yml = File.read(File.expand_path("../shard.yml", __DIR__))
+    if match = shard_yml.match(/^version:\s*(\S+)\s*$/m)
+      App::VERSION.should eq(match[1])
+    else
+      fail "shard.yml has no version field"
+    end
+  end
 end
 
 describe CycloneDX::BOM do

--- a/src/app.cr
+++ b/src/app.cr
@@ -1,4 +1,5 @@
 require "option_parser"
+require "spdx"
 require "./cyclonedx/bom"
 require "./cyclonedx/component"
 require "./cyclonedx/models"
@@ -9,7 +10,7 @@ require "./shard/shard_lock_file"
 # Main application class for generating CycloneDX SBOMs from Crystal Shard files.
 # Handles command-line argument parsing, file reading, and SBOM generation.
 class App
-  VERSION            = "1.2.0"
+  VERSION            = "1.3.0"
   SUPPORTED_VERSIONS = CycloneDX::BOM::SUPPORTED_VERSIONS
   SUPPORTED_FORMATS  = ["json", "xml", "csv"]
   DEFAULT_VERSION    = "1.6"
@@ -192,15 +193,27 @@ class App
   # SPDX license expression operators
   private SPDX_EXPRESSION_PATTERN = /\b(AND|OR|WITH)\b/
 
+  # Build a licenses array for a shard.yml license field.
+  #
+  # - Compound expressions (containing AND/OR/WITH) become LicenseExpression.
+  # - Single identifiers that exist in the SPDX catalog use the canonical `id`.
+  # - Identifiers not in the SPDX catalog fall back to `name`.
+  private def build_licenses(license : String) : Array(CycloneDX::License | CycloneDX::LicenseExpression)
+    if license =~ SPDX_EXPRESSION_PATTERN
+      [CycloneDX::LicenseExpression.new(expression: license)] of CycloneDX::License | CycloneDX::LicenseExpression
+    elsif Spdx.license?(license)
+      canonical = Spdx.find_license(license).id
+      [CycloneDX::License.new(id: canonical)] of CycloneDX::License | CycloneDX::LicenseExpression
+    else
+      [CycloneDX::License.new(name: license)] of CycloneDX::License | CycloneDX::LicenseExpression
+    end
+  end
+
   # Parses the main component information from a parsed ShardFile.
   private def parse_main_component(shard : ShardFile) : CycloneDX::Component
     licenses = nil
     shard.license.try do |license|
-      if license =~ SPDX_EXPRESSION_PATTERN
-        licenses = [CycloneDX::LicenseExpression.new(expression: license)] of CycloneDX::License | CycloneDX::LicenseExpression
-      else
-        licenses = [CycloneDX::License.new(name: license)] of CycloneDX::License | CycloneDX::LicenseExpression
-      end
+      licenses = build_licenses(license)
     end
 
     external_refs = [

--- a/src/cyclonedx/models.cr
+++ b/src/cyclonedx/models.cr
@@ -43,6 +43,36 @@ module CycloneDX
                    @acknowledgement : String? = nil)
     end
 
+    # CycloneDX LicenseChoice wraps the license object: `{"license": {...}}`.
+    # We override `to_json` (the JSON::Serializable-generated implementation
+    # would produce a flat object). `from_json` keeps the flat shape, which is
+    # fine because we never parse SBOM `licenses` arrays back in.
+    # `id` is preferred when present (canonical SPDX identifier);
+    # `name` is the free-form fallback for licenses not in the SPDX list.
+    def to_json(json : JSON::Builder)
+      json.object do
+        json.field "license" do
+          json.object do
+            if id_val = @id
+              json.field "id", id_val
+            elsif name_val = @name
+              json.field "name", name_val
+            end
+            if url_val = @url
+              json.field "url", url_val
+            end
+            if bom_ref_val = @bom_ref
+              json.field "bom-ref", bom_ref_val
+            end
+            if ack = @acknowledgement
+              json.field "acknowledgement", ack
+            end
+            @text.try { |t| json.field("text") { t.to_json(json) } }
+          end
+        end
+      end
+    end
+
     def to_xml(xml : XML::Builder)
       attrs = {} of String => String
       if bom_ref_val = @bom_ref


### PR DESCRIPTION
## Summary

### Bug — License JSON shape did not match the CycloneDX schema

Previous output:
\`\`\`json
"licenses": [{ "name": "MIT" }]
\`\`\`

CycloneDX 1.4–1.7 LicenseChoice wraps the license object:
\`\`\`json
"licenses": [{ "license": { "id": "MIT" } }]
\`\`\`

XML already emitted \`<licenses><license>...</license></licenses>\` so this is a JSON-only fix. Override \`License#to_json\` to wrap; \`from_json\` keeps the flat shape because cyclonedx-cr never parses license arrays back in. Spec assertions and one fixture updated to the new shape.

### Improve — Use canonical SPDX id when the identifier is known

\`shard.yml\`'s \`license: MIT\` was always emitted as a free-form \`name\`, even though MIT is a canonical SPDX identifier. Add \`spdx\` (hahwul/spdx.cr) as a runtime dep and route the license string through a new \`build_licenses\` helper:

- compound expressions (AND / OR / WITH) → \`LicenseExpression\`
- identifier known to the SPDX list → \`{"license":{"id":"<canonical>"}}\`
- unknown identifier → \`{"license":{"name":"<raw>"}}\`

New fixture \`spec/fixtures/custom_license_shard.yml\` exercises the non-SPDX fallback.

### Fix — App::VERSION drifted from shard.yml

\`src/app.cr\` had \`VERSION = "1.2.0"\` while \`shard.yml\` is 1.3.0, so the SBOM's \`tools[].version\` reported the stale value. Bump \`App::VERSION\`, add it to \`just version-check\` / \`just version-update\` so it cannot drift silently again, and add a spec asserting \`App::VERSION == shard.yml#version\`.

## Test plan

- [x] \`crystal spec\` was 248 → 250 (added version-sync spec, SPDX-id integration spec; updated assertions that expected the flat license shape).
- [x] \`just version-check\` clean across all tracked files.
- [x] \`cyclonedx-cr -s spec/fixtures/shard.yml\` now emits \`{"license":{"id":"MIT"}}\`.
- [x] \`cyclonedx-cr -s spec/fixtures/custom_license_shard.yml\` emits \`{"license":{"name":"Proprietary"}}\`.