### PR TITLE
feat: spec-version field gating + validation; remove non-existent 1.7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file contains instructions for AI agents working on the `cyclonedx-cr` proj
 
 - **Language:** Crystal
 - **Build System:** Shards
-- **Spec Versions:** CycloneDX 1.4, 1.5, 1.6, 1.7
+- **Spec Versions:** CycloneDX 1.4, 1.5, 1.6
 - **Output Formats:** JSON, XML, CSV
 
 ## Directory Structure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,16 @@
 - License entries now follow the CycloneDX `LicenseChoice` shape:
   `{"license": {...}}` instead of a flat `{"id":"...","name":"..."}`.
   XML output already used `<license>...</license>` so this is a JSON-only
-  fix that aligns with the 1.4–1.7 schemas.
+  fix that aligns with the 1.4–1.6 schemas.
+- Removed the unsupported CycloneDX "1.7" spec version. 1.6 is the latest
+  published spec; no validator accepts 1.7 and there is no 1.7 schema.
+  Supported versions are now 1.4, 1.5, and 1.6 (default 1.6).
+- `alg` (hash algorithm) and external-reference `type` are now validated
+  against the CycloneDX enums in the model constructors.
+- Version-less `path:` lock entries and version-less `shard.yml` no longer
+  crash; `version` defaults to `"unknown"` when absent.
+- `read_yaml_file` now distinguishes invalid YAML from a missing required
+  attribute and reports an accurate error message for each.
 
 ### Changed
 - License identifiers that exist in the SPDX license list are now emitted

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Crystal tool for generating [CycloneDX](https://cyclonedx.org/) Software Bill 
 
 - Generates CycloneDX SBOMs from Crystal `shard.yml` and `shard.lock` files
 - Supports multiple output formats: JSON, XML, CSV
-- Compatible with CycloneDX spec versions 1.4, 1.5, 1.6, and 1.7
+- Compatible with CycloneDX spec versions 1.4, 1.5, and 1.6
 - Automatically generates Package URLs (PURLs) for dependencies
 - Docker support for containerized usage
 - Fast and lightweight implementation in Crystal
@@ -76,7 +76,7 @@ Usage: cyclonedx-cr [arguments]
     -i FILE, --input=FILE            shard.lock file path (default: shard.lock)
     -s FILE, --shard=FILE            shard.yml file path (default: shard.yml)
     -o FILE, --output=FILE           Output file path (default: stdout)
-    --spec-version VERSION           CycloneDX spec version (options: 1.4, 1.5, 1.6, 1.7, default: 1.6)
+    --spec-version VERSION           CycloneDX spec version (options: 1.4, 1.5, 1.6, default: 1.6)
     --output-format FORMAT           Output format (options: json, xml, csv, default: json)
     -h, --help                       Show this help
 ```
@@ -166,7 +166,6 @@ Simplified comma-separated values format for basic analysis and reporting.
 
 ## CycloneDX Specification Versions
 
-- **1.7**: Latest version with full feature support
 - **1.6** (default): Latest stable version with broad compatibility
 - **1.5**: Stable version with broad tool compatibility
 - **1.4**: Legacy version for compatibility with older tools

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
     default: ""
   spec_version:
-    description: "CycloneDX spec version (options: 1.4, 1.5, 1.6, 1.7)"
+    description: "CycloneDX spec version (options: 1.4, 1.5, 1.6)"
     required: false
     default: "1.6"
   output_format:

--- a/spec/app_integration_spec.cr
+++ b/spec/app_integration_spec.cr
@@ -43,6 +43,21 @@ describe "App Integration" do
       output.should contain("not found")
       $?.success?.should be_false
     end
+
+    it "reports a YAML syntax error accurately for malformed YAML" do
+      output = `#{BINARY} -s #{FIXTURES}/invalid_syntax_shard.yml -i #{FIXTURES}/empty_lock.lock 2>&1`
+      $?.success?.should be_false
+      output.should contain("ensure the file contains valid YAML")
+      output.should_not contain("missing a required field")
+    end
+
+    it "reports a missing required field without claiming the YAML is invalid" do
+      # missing_name_shard.yml is valid YAML but omits the required `name`.
+      output = `#{BINARY} -s #{FIXTURES}/missing_name_shard.yml -i #{FIXTURES}/empty_lock.lock 2>&1`
+      $?.success?.should be_false
+      output.should contain("missing a required field")
+      output.should_not contain("ensure the file contains valid YAML")
+    end
   end
 
   describe "JSON output" do

--- a/spec/cyclonedx/models_spec.cr
+++ b/spec/cyclonedx/models_spec.cr
@@ -171,6 +171,19 @@ describe CycloneDX::Hash do
       hash.algorithm.should eq("SHA-256")
       hash.content.should eq("abc123")
     end
+
+    it "accepts every algorithm in the CycloneDX enum" do
+      CycloneDX::Hash::VALID_ALGORITHMS.each do |alg|
+        hash = CycloneDX::Hash.new(algorithm: alg, content: "abc123")
+        hash.algorithm.should eq(alg)
+      end
+    end
+
+    it "raises on an algorithm not in the enum" do
+      expect_raises(ArgumentError, "Invalid hash algorithm 'SHA-999'") do
+        CycloneDX::Hash.new(algorithm: "SHA-999", content: "abc123")
+      end
+    end
   end
 
   describe "#to_json" do
@@ -205,6 +218,24 @@ describe CycloneDX::ExternalReference do
     it "initializes with comment" do
       ref = CycloneDX::ExternalReference.new(ref_type: "vcs", url: "https://github.com/foo/bar", comment: "Main repo")
       ref.comment.should eq("Main repo")
+    end
+
+    it "accepts the 'other' catch-all type" do
+      ref = CycloneDX::ExternalReference.new(ref_type: "other", url: "https://example.com")
+      ref.ref_type.should eq("other")
+    end
+
+    it "accepts every type in the CycloneDX enum" do
+      CycloneDX::ExternalReference::VALID_TYPES.each do |ref_type|
+        ref = CycloneDX::ExternalReference.new(ref_type: ref_type, url: "https://example.com")
+        ref.ref_type.should eq(ref_type)
+      end
+    end
+
+    it "raises on a type not in the enum" do
+      expect_raises(ArgumentError, "Invalid external reference type 'made-up'") do
+        CycloneDX::ExternalReference.new(ref_type: "made-up", url: "https://example.com")
+      end
     end
   end
 

--- a/spec/cyclonedx/validator_spec.cr
+++ b/spec/cyclonedx/validator_spec.cr
@@ -129,6 +129,52 @@ describe CycloneDX::Validator do
       validator.validate(bom).should be_true
     end
 
+    it "detects an invalid hash algorithm on a deserialized component" do
+      # `from_json` bypasses the constructor guard, so the Validator must
+      # still catch an out-of-enum algorithm.
+      json = %q({
+        "bomFormat":"CycloneDX","specVersion":"1.6","version":1,
+        "serialNumber":"urn:uuid:test",
+        "components":[{
+          "type":"library","name":"lib","version":"1.0",
+          "hashes":[{"alg":"SHA-999","content":"deadbeef"}]
+        }]
+      })
+      bom = CycloneDX::BOM.from_json(json)
+      validator = CycloneDX::Validator.new
+      validator.validate(bom).should be_false
+      validator.errors.any? { |e| e.path.includes?("hashes[0].alg") && e.message.includes?("SHA-999") }.should be_true
+    end
+
+    it "passes a valid hash algorithm" do
+      hashes = [CycloneDX::Hash.new(algorithm: "SHA-512", content: "deadbeef")]
+      comp = CycloneDX::Component.new(name: "lib", version: "1.0", hashes: hashes)
+      bom = CycloneDX::BOM.new([comp], "1.6")
+      validator = CycloneDX::Validator.new
+      validator.validate(bom).should be_true
+    end
+
+    it "detects an invalid external reference type on a deserialized BOM" do
+      json = %q({
+        "bomFormat":"CycloneDX","specVersion":"1.6","version":1,
+        "serialNumber":"urn:uuid:test",
+        "components":[],
+        "externalReferences":[{"type":"made-up","url":"https://example.com"}]
+      })
+      bom = CycloneDX::BOM.from_json(json)
+      validator = CycloneDX::Validator.new
+      validator.validate(bom).should be_false
+      validator.errors.any? { |e| e.path.includes?("externalReferences[0].type") && e.message.includes?("made-up") }.should be_true
+    end
+
+    it "passes a valid external reference type" do
+      ref = CycloneDX::ExternalReference.new(ref_type: "website", url: "https://example.com")
+      comp = CycloneDX::Component.new(name: "lib", version: "1.0", external_references: [ref])
+      bom = CycloneDX::BOM.new([comp], "1.6")
+      validator = CycloneDX::Validator.new
+      validator.validate(bom).should be_true
+    end
+
     it "formats error messages with to_s" do
       comp = CycloneDX::Component.new(name: "", version: "1.0")
       bom = CycloneDX::BOM.new([comp], "1.6")

--- a/spec/cyclonedx/version_gate_spec.cr
+++ b/spec/cyclonedx/version_gate_spec.cr
@@ -1,0 +1,232 @@
+require "spec"
+require "../../src/cyclonedx/bom"
+require "../../src/cyclonedx/metadata"
+require "../../src/cyclonedx/validator"
+require "../../src/cyclonedx/annotation"
+require "../../src/cyclonedx/declaration"
+
+# Normalises a serialized BOM so two outputs can be compared on their *core*
+# structure only (the per-version `specVersion` and the random `serialNumber`
+# are masked out).
+private def normalize_core(json : String) : String
+  json
+    .gsub(/"specVersion":"[^"]+"/, %("specVersion":"X"))
+    .gsub(/"serialNumber":"[^"]+"/, %("serialNumber":"X"))
+end
+
+# Builds a bare "shards-generator"-shaped BOM using only core fields.
+private def core_bom(version : String) : CycloneDX::BOM
+  tool = CycloneDX::Tool.new(vendor: "hahwul", name: "cyclonedx-cr", version: "1.3.0")
+  main = CycloneDX::Component.new(
+    component_type: "application", name: "myapp", version: "1.0",
+    licenses: [CycloneDX::License.new(id: "MIT")] of CycloneDX::License | CycloneDX::LicenseExpression,
+    external_references: [CycloneDX::ExternalReference.new(ref_type: "vcs", url: "https://github.com/x/y")],
+    bom_ref: "myapp@1.0"
+  )
+  md = CycloneDX::Metadata.new(component: main, tools: [tool], timestamp: "2024-01-01T00:00:00Z")
+  dep = CycloneDX::Component.new(
+    name: "lib-a", version: "2.0", purl: "pkg:github/x/a@2.0",
+    bom_ref: "lib-a@2.0", scope: "required",
+    hashes: [CycloneDX::Hash.new(algorithm: "SHA-256", content: "deadbeef")]
+  )
+  graph = [
+    CycloneDX::Dependency.new(ref: "myapp@1.0", depends_on: ["lib-a@2.0"]),
+    CycloneDX::Dependency.new(ref: "lib-a@2.0"),
+  ]
+  CycloneDX::BOM.new([dep], version, metadata: md, dependencies: graph)
+end
+
+describe CycloneDX::VersionGate do
+  describe "(a) metadata.lifecycles / bom.annotations gating" do
+    it "does NOT emit lifecycles or annotations when declared as 1.4" do
+      lc = CycloneDX::Lifecycle.new(phase: "build")
+      md = CycloneDX::Metadata.new(lifecycles: [lc], timestamp: "2024-01-01T00:00:00Z")
+      ann = CycloneDX::Annotation.new(text: "Reviewed")
+      bom = CycloneDX::BOM.new([] of CycloneDX::Component, "1.4", metadata: md, annotations: [ann])
+
+      json = bom.to_json
+      json.should_not contain(%("lifecycles"))
+      json.should_not contain(%("annotations"))
+
+      xml = bom.to_xml
+      xml.should_not contain("<lifecycles>")
+      xml.should_not contain("<annotations>")
+    end
+
+    it "DOES emit lifecycles and annotations when declared as 1.5" do
+      lc = CycloneDX::Lifecycle.new(phase: "build")
+      md = CycloneDX::Metadata.new(lifecycles: [lc], timestamp: "2024-01-01T00:00:00Z")
+      ann = CycloneDX::Annotation.new(text: "Reviewed")
+      bom = CycloneDX::BOM.new([] of CycloneDX::Component, "1.5", metadata: md, annotations: [ann])
+
+      json = bom.to_json
+      json.should contain(%("lifecycles"))
+      json.should contain(%("annotations"))
+
+      xml = bom.to_xml
+      xml.should contain("<lifecycles>")
+      xml.should contain("<annotations>")
+    end
+  end
+
+  describe "(b) 1.6-only component / license fields gated under 1.4 and 1.5" do
+    it "strips component tags, cryptoProperties, authors array, and license bom-ref under 1.4" do
+      comp = CycloneDX::Component.new(
+        name: "lib", version: "1.0.0",
+        tags: ["a", "b"],
+        authors: [CycloneDX::OrganizationalContact.new(name: "Jane")],
+        crypto_properties: CycloneDX::CryptoProperties.new(asset_type: "algorithm"),
+        author: "single-author-string",
+        licenses: [CycloneDX::License.new(id: "MIT", bom_ref: "lic-1", acknowledgement: "declared")] of CycloneDX::License | CycloneDX::LicenseExpression
+      )
+      bom = CycloneDX::BOM.new([comp], "1.4")
+
+      json = bom.to_json
+      json.should_not contain(%("tags"))
+      json.should_not contain(%("cryptoProperties"))
+      json.should_not contain(%("authors"))
+      json.should_not contain(%("bom-ref":"lic-1"))
+      json.should_not contain(%("acknowledgement"))
+      # the single `author` string is older than 1.6 and must be kept
+      json.should contain(%("author":"single-author-string"))
+
+      xml = bom.to_xml
+      xml.should_not contain("<tags>")
+      xml.should_not contain("<authors>")
+      xml.should_not contain("<cryptoProperties>")
+      xml.should_not contain(%(bom-ref="lic-1"))
+      xml.should_not contain("acknowledgement=")
+      xml.should contain("<author>single-author-string</author>")
+    end
+
+    it "still strips the same 1.6 fields under 1.5 (but keeps 1.5 modelCard)" do
+      comp = CycloneDX::Component.new(
+        name: "lib", version: "1.0.0",
+        tags: ["a"],
+        authors: [CycloneDX::OrganizationalContact.new(name: "Jane")],
+        crypto_properties: CycloneDX::CryptoProperties.new(asset_type: "algorithm"),
+        model_card: CycloneDX::ModelCard.new(bom_ref: "mc-1"),
+        licenses: [CycloneDX::License.new(id: "MIT", bom_ref: "lic-1")] of CycloneDX::License | CycloneDX::LicenseExpression
+      )
+      bom = CycloneDX::BOM.new([comp], "1.5")
+
+      json = bom.to_json
+      json.should_not contain(%("tags"))
+      json.should_not contain(%("cryptoProperties"))
+      json.should_not contain(%("authors"))
+      json.should_not contain(%("bom-ref":"lic-1"))
+      # modelCard is 1.5+, so it stays at 1.5
+      json.should contain(%("modelCard"))
+    end
+
+    it "emits all 1.6 fields when declared as 1.6" do
+      comp = CycloneDX::Component.new(
+        name: "lib", version: "1.0.0",
+        tags: ["a"],
+        authors: [CycloneDX::OrganizationalContact.new(name: "Jane")],
+        crypto_properties: CycloneDX::CryptoProperties.new(asset_type: "algorithm"),
+        licenses: [CycloneDX::License.new(id: "MIT", bom_ref: "lic-1", acknowledgement: "declared")] of CycloneDX::License | CycloneDX::LicenseExpression
+      )
+      bom = CycloneDX::BOM.new([comp], "1.6")
+
+      json = bom.to_json
+      json.should contain(%("tags"))
+      json.should contain(%("cryptoProperties"))
+      json.should contain(%("authors"))
+      json.should contain(%("bom-ref":"lic-1"))
+      json.should contain(%("acknowledgement"))
+    end
+  end
+
+  describe "(c) bare shards-generator output stays schema-shaped across versions" do
+    it "produces identical core JSON for 1.4 / 1.5 / 1.6" do
+      j14 = normalize_core(core_bom("1.4").to_json)
+      j15 = normalize_core(core_bom("1.5").to_json)
+      j16 = normalize_core(core_bom("1.6").to_json)
+
+      j14.should eq(j15)
+      j15.should eq(j16)
+    end
+
+    it "keeps all core fields present at every version" do
+      %w[1.4 1.5 1.6].each do |v|
+        json = core_bom(v).to_json
+        json.should contain(%("bomFormat":"CycloneDX"))
+        json.should contain(%("specVersion":"#{v}"))
+        json.should contain(%("serialNumber":"urn:uuid:))
+        json.should contain(%("timestamp"))
+        json.should contain(%("tools"))
+        json.should contain(%("bom-ref":"myapp@1.0"))
+        json.should contain(%("type":"application"))
+        json.should contain(%("purl":"pkg:github/x/a@2.0"))
+        json.should contain(%("scope":"required"))
+        json.should contain(%("licenses"))
+        json.should contain(%("hashes"))
+        json.should contain(%("externalReferences"))
+        json.should contain(%("dependencies"))
+      end
+    end
+
+    it "produces a bare BOM that has no gating violations at any version" do
+      %w[1.4 1.5 1.6].each do |v|
+        validator = CycloneDX::Validator.new
+        validator.validate(core_bom(v)).should be_true
+        validator.errors.should be_empty
+      end
+    end
+  end
+
+  describe "(d) validator flags a 1.6 field set under specVersion 1.4" do
+    it "reports gating errors for component and bom-level 1.6 fields" do
+      comp = CycloneDX::Component.new(
+        name: "lib", version: "1.0.0",
+        tags: ["a"],
+        crypto_properties: CycloneDX::CryptoProperties.new(asset_type: "algorithm"),
+        authors: [CycloneDX::OrganizationalContact.new(name: "Jane")]
+      )
+      defs = CycloneDX::Definitions.new(standards: [CycloneDX::DefinitionStandard.new(name: "NIST")])
+      bom = CycloneDX::BOM.new([comp], "1.4", definitions: defs)
+
+      validator = CycloneDX::Validator.new
+      validator.validate(bom).should be_false
+
+      messages = validator.errors.map(&.message)
+      validator.errors.any? { |e| e.path == "$.components[0].tags" }.should be_true
+      validator.errors.any? { |e| e.path == "$.components[0].cryptoProperties" }.should be_true
+      validator.errors.any? { |e| e.path == "$.components[0].authors" }.should be_true
+      validator.errors.any? { |e| e.path == "$.definitions" }.should be_true
+      messages.all?(&.includes?("specVersion")).should be_true
+    end
+
+    it "reports a 1.5 field (lifecycles/annotations) under 1.4" do
+      lc = CycloneDX::Lifecycle.new(phase: "build")
+      md = CycloneDX::Metadata.new(lifecycles: [lc])
+      ann = CycloneDX::Annotation.new(text: "note")
+      bom = CycloneDX::BOM.new([] of CycloneDX::Component, "1.4", metadata: md, annotations: [ann])
+
+      validator = CycloneDX::Validator.new
+      validator.validate(bom).should be_false
+      validator.errors.any? { |e| e.path == "$.metadata.lifecycles" }.should be_true
+      validator.errors.any? { |e| e.path == "$.annotations" }.should be_true
+    end
+
+    it "does NOT flag those fields when the declared version supports them" do
+      comp = CycloneDX::Component.new(
+        name: "lib", version: "1.0.0",
+        tags: ["a"],
+        crypto_properties: CycloneDX::CryptoProperties.new(asset_type: "algorithm")
+      )
+      bom = CycloneDX::BOM.new([comp], "1.6")
+      validator = CycloneDX::Validator.new
+      validator.validate(bom).should be_true
+      validator.errors.should be_empty
+    end
+
+    it "does NOT flag the single component.author string under 1.4" do
+      comp = CycloneDX::Component.new(name: "lib", version: "1.0.0", author: "Jane Doe")
+      bom = CycloneDX::BOM.new([comp], "1.4")
+      validator = CycloneDX::Validator.new
+      validator.validate(bom).should be_true
+    end
+  end
+end

--- a/spec/fixtures/invalid_syntax_shard.yml
+++ b/spec/fixtures/invalid_syntax_shard.yml
@@ -1,0 +1,4 @@
+name: broken
+version: 0.1.0
+  : : not valid yaml : :
+ - dangling

--- a/spec/fixtures/missing_name_shard.yml
+++ b/spec/fixtures/missing_name_shard.yml
@@ -1,0 +1,2 @@
+version: 0.1.0
+description: Valid YAML but missing the required name field

--- a/spec/main_spec.cr
+++ b/spec/main_spec.cr
@@ -44,11 +44,12 @@ describe CycloneDX::BOM do
       json.should contain(%("specVersion":"1.6"))
     end
 
-    it "supports spec version 1.7" do
+    it "rejects the unsupported 1.7 spec version" do
+      # 1.6 is the latest published CycloneDX spec; 1.7 does not exist.
       components = [CycloneDX::Component.new("test", "1.0.2")]
-      bom = CycloneDX::BOM.new(components: components, spec_version: "1.7")
-      json = bom.to_json
-      json.should contain(%("specVersion":"1.7"))
+      expect_raises(ArgumentError, "Unsupported spec version") do
+        CycloneDX::BOM.new(components: components, spec_version: "1.7")
+      end
     end
 
     it "raises on unsupported spec version" do
@@ -58,11 +59,19 @@ describe CycloneDX::BOM do
       end
     end
 
-    it "generates correct XML namespace for spec version 1.7" do
+    it "generates correct XML namespace for spec version 1.6" do
       components = [CycloneDX::Component.new("test", "1.0.2")]
-      bom = CycloneDX::BOM.new(components: components, spec_version: "1.7")
+      bom = CycloneDX::BOM.new(components: components, spec_version: "1.6")
       xml = bom.to_xml
-      xml.should contain(%(xmlns="http://cyclonedx.org/schema/bom/1.7"))
+      xml.should contain(%(xmlns="http://cyclonedx.org/schema/bom/1.6"))
+    end
+
+    it "never emits a 1.7 XML namespace for any supported version" do
+      CycloneDX::BOM::SUPPORTED_VERSIONS.each do |version|
+        components = [CycloneDX::Component.new("test", "1.0.2")]
+        bom = CycloneDX::BOM.new(components: components, spec_version: version)
+        bom.to_xml.should_not contain("/bom/1.7")
+      end
     end
   end
 end

--- a/spec/shard_file_spec.cr
+++ b/spec/shard_file_spec.cr
@@ -44,9 +44,21 @@ describe ShardFile do
       shard.repository.should be_nil
     end
 
-    it "raises an error when required fields are missing" do
+    it "parses a shard.yml without a version (defaults to 'unknown')" do
       yaml = <<-YAML
-        description: Missing name and version
+        name: app-only
+        YAML
+
+      shard = ShardFile.from_yaml(yaml)
+
+      shard.name.should eq "app-only"
+      shard.version.should eq "unknown"
+    end
+
+    it "raises an error when the required name field is missing" do
+      yaml = <<-YAML
+        description: Missing name
+        version: 1.0.0
         YAML
 
       expect_raises(YAML::ParseException) do

--- a/spec/shard_lock_file_spec.cr
+++ b/spec/shard_lock_file_spec.cr
@@ -60,6 +60,22 @@ describe ShardLockFile do
       shard.github.should be_nil
     end
 
+    it "parses a path dependency without a version (defaults to 'unknown')" do
+      yaml = <<-YAML
+        version: 2.0
+        shards:
+          local_shard:
+            path: /path/to/shard
+        YAML
+
+      lock_file = ShardLockFile.from_yaml(yaml)
+      lock_file.shards.size.should eq(1)
+
+      shard = lock_file.shards["local_shard"]
+      shard.path.should eq("/path/to/shard")
+      shard.version.should eq("unknown")
+    end
+
     it "parses an empty shards section" do
       yaml = <<-YAML
         version: 2.0

--- a/src/app.cr
+++ b/src/app.cr
@@ -173,7 +173,14 @@ class App
   private def read_yaml_file(file_path : String, type : T.class) : T forall T
     File.open(file_path) { |file| T.from_yaml(file) }
   rescue ex : YAML::ParseException
-    STDERR.puts "Error: Failed to parse `#{file_path}`. Please ensure the file contains valid YAML."
+    # `YAML::Serializable` raises `YAML::ParseException` both for invalid YAML
+    # syntax and for valid YAML that is missing a required attribute. The two
+    # cases need different guidance, so distinguish them by the message.
+    if (msg = ex.message) && msg.includes?("Missing YAML attribute")
+      STDERR.puts "Error: `#{file_path}` is valid YAML but is missing a required field."
+    else
+      STDERR.puts "Error: Failed to parse `#{file_path}`. Please ensure the file contains valid YAML."
+    end
     STDERR.puts ex.message
     exit(1)
   rescue ex : File::Error

--- a/src/cyclonedx/bom.cr
+++ b/src/cyclonedx/bom.cr
@@ -11,6 +11,7 @@ require "./composition"
 require "./annotation"
 require "./formulation"
 require "./declaration"
+require "./version_gate"
 
 # Represents a CycloneDX Bill of Materials (BOM).
 # This class manages a collection of components and provides methods
@@ -69,7 +70,7 @@ class CycloneDX::BOM
   # Definitions for standards (1.5+).
   getter definitions : Definitions?
 
-  SUPPORTED_VERSIONS = ["1.4", "1.5", "1.6", "1.7"]
+  SUPPORTED_VERSIONS = ["1.4", "1.5", "1.6"]
 
   # Initializes a new CycloneDX BOM.
   def initialize(@components : Array(Component), @spec_version : String,
@@ -84,8 +85,27 @@ class CycloneDX::BOM
     end
   end
 
+  # Serializes the BOM to JSON.
+  #
+  # The object model may carry fields newer than the declared `specVersion`
+  # (e.g. a 1.4 BOM that was handed `lifecycles`). To keep the output
+  # schema-valid, the raw serialization is filtered through `VersionGate`,
+  # which strips any key newer than `@spec_version`.
+  def to_json : String
+    raw = String.build do |str|
+      JSON.build(str) { |json| to_json(json) }
+    end
+    VersionGate.filter_json(raw, @spec_version)
+  end
+
   # Serializes the BOM to XML format.
   def to_xml : String
+    raw = build_xml
+    VersionGate.filter_xml(raw, @spec_version)
+  end
+
+  # Builds the raw (unfiltered) XML for the BOM.
+  private def build_xml : String
     String.build do |str|
       XML.build(str) do |xml|
         xml.element("bom", attributes: {

--- a/src/cyclonedx/models.cr
+++ b/src/cyclonedx/models.cr
@@ -126,11 +126,21 @@ module CycloneDX
   class Hash
     include JSON::Serializable
 
+    # Valid hash algorithm enum values per the CycloneDX schema (`hash-alg`).
+    VALID_ALGORITHMS = [
+      "MD5", "SHA-1", "SHA-256", "SHA-384", "SHA-512",
+      "SHA3-256", "SHA3-384", "SHA3-512",
+      "BLAKE2b-256", "BLAKE2b-384", "BLAKE2b-512", "BLAKE3",
+    ]
+
     @[JSON::Field(key: "alg")]
     getter algorithm : String
     getter content : String
 
     def initialize(@algorithm : String, @content : String)
+      unless VALID_ALGORITHMS.includes?(@algorithm)
+        raise ArgumentError.new("Invalid hash algorithm '#{@algorithm}'. Valid algorithms are: #{VALID_ALGORITHMS.join(", ")}")
+      end
     end
 
     def to_xml(xml : XML::Builder)
@@ -143,6 +153,22 @@ module CycloneDX
   class ExternalReference
     include JSON::Serializable
 
+    # Valid externalReference type enum values per the CycloneDX schema
+    # (`externalReferenceType`). "other" is the catch-all fallback.
+    VALID_TYPES = [
+      "vcs", "issue-tracker", "website", "advisories", "bom", "mailing-list",
+      "social", "chat", "documentation", "support", "source-distribution",
+      "distribution", "distribution-intake", "license", "build-meta",
+      "build-system", "release-notes", "security-contact", "model-card",
+      "log", "configuration", "evidence", "formulation", "attestation",
+      "threat-model", "adversary-model", "risk-register",
+      "vulnerability-assertion", "exploitability-statement", "pentest-report",
+      "static-analysis-report", "dynamic-analysis-report",
+      "runtime-analysis-report", "component-analysis-report", "maturity-report",
+      "certification-report", "codified-infrastructure", "quality-metrics",
+      "poam", "electronic-signature", "digital-signature", "rfc-9116", "other",
+    ]
+
     @[JSON::Field(key: "type")]
     getter ref_type : String
     getter url : String
@@ -150,6 +176,9 @@ module CycloneDX
     getter hashes : Array(Hash)?
 
     def initialize(@ref_type : String, @url : String, @comment : String? = nil, @hashes : Array(Hash)? = nil)
+      unless VALID_TYPES.includes?(@ref_type)
+        raise ArgumentError.new("Invalid external reference type '#{@ref_type}'. Valid types are: #{VALID_TYPES.join(", ")}")
+      end
     end
 
     def to_xml(xml : XML::Builder)

--- a/src/cyclonedx/validator.cr
+++ b/src/cyclonedx/validator.cr
@@ -1,5 +1,6 @@
 require "./bom"
 require "./formulation"
+require "./version_gate"
 
 module CycloneDX
   class ValidationError
@@ -36,6 +37,12 @@ module CycloneDX
         validate_component(comp, "$.components[#{i}]")
       end
 
+      if ext_refs = bom.external_references
+        ext_refs.each_with_index do |ref, i|
+          validate_external_reference(ref, "$.externalReferences[#{i}]")
+        end
+      end
+
       if svcs = bom.services
         svcs.each_with_index do |svc, i|
           validate_service(svc, "$.services[#{i}]")
@@ -63,6 +70,18 @@ module CycloneDX
       if md = bom.metadata
         validate_metadata(md, "$.metadata")
       end
+
+      validate_spec_version_fields(bom)
+    end
+
+    # Flags any field that is populated on the object model but is newer than
+    # the declared `specVersion`. Such fields would be stripped on
+    # serialization, so surfacing them as errors tells direct object-model
+    # users their BOM is over-specified for the version they declared.
+    private def validate_spec_version_fields(bom : BOM)
+      VersionGate.each_violation(bom) do |v|
+        add_error("#{v.path}.#{v.field}", "field '#{v.field}' requires specVersion >= #{v.min_version}, but BOM declares #{bom.spec_version}")
+      end
     end
 
     private def validate_component(comp : Component, path : String)
@@ -79,9 +98,39 @@ module CycloneDX
         end
       end
 
+      if hashes = comp.hashes
+        hashes.each_with_index do |hash, i|
+          validate_hash(hash, "#{path}.hashes[#{i}]")
+        end
+      end
+
+      if ext_refs = comp.external_references
+        ext_refs.each_with_index do |ref, i|
+          validate_external_reference(ref, "#{path}.externalReferences[#{i}]")
+        end
+      end
+
       if sub = comp.components
         sub.each_with_index do |c, i|
           validate_component(c, "#{path}.components[#{i}]")
+        end
+      end
+    end
+
+    private def validate_hash(hash : Hash, path : String)
+      unless Hash::VALID_ALGORITHMS.includes?(hash.algorithm)
+        add_error("#{path}.alg", "invalid hash algorithm '#{hash.algorithm}', valid: #{Hash::VALID_ALGORITHMS.join(", ")}")
+      end
+    end
+
+    private def validate_external_reference(ref : ExternalReference, path : String)
+      unless ExternalReference::VALID_TYPES.includes?(ref.ref_type)
+        add_error("#{path}.type", "invalid external reference type '#{ref.ref_type}', valid: #{ExternalReference::VALID_TYPES.join(", ")}")
+      end
+
+      if hashes = ref.hashes
+        hashes.each_with_index do |hash, i|
+          validate_hash(hash, "#{path}.hashes[#{i}]")
         end
       end
     end

--- a/src/cyclonedx/version_gate.cr
+++ b/src/cyclonedx/version_gate.cr
@@ -1,0 +1,309 @@
+require "json"
+require "xml"
+
+module CycloneDX
+  # Spec-version field gating.
+  #
+  # CycloneDX added fields over successive spec versions. A BOM declared as
+  # `specVersion` 1.4 must NEVER contain fields that were only introduced in
+  # 1.5 or 1.6, otherwise it fails schema validation. The same applies to a
+  # 1.5 BOM with respect to 1.6-only fields.
+  #
+  # `VersionGate` is the single source of truth for "which field was added in
+  # which version". It drives:
+  #   * a post-serialization JSON filter (`filter_json`),
+  #   * an equivalent XML filter (`filter_xml`),
+  #   * the `Validator` (so direct object-model users get told when they
+  #     populated a field newer than the declared `specVersion`).
+  #
+  # The map is keyed by *context* (the kind of object a field lives in) rather
+  # than by bare field name, because some names are ambiguous (e.g. `tags`
+  # exists on `component` only from 1.6 but on `releaseNotes` since 1.4, and
+  # `bom-ref` is core on a component but 1.6-only on a license).
+  module VersionGate
+    # Ordering of the supported spec versions, oldest first.
+    VERSION_ORDER = {"1.4" => 0, "1.5" => 1, "1.6" => 2}
+
+    # Returns true when `field_version` is newer than the declared
+    # `spec_version` (i.e. the field must be stripped / flagged).
+    def self.newer?(field_version : String, spec_version : String) : Bool
+      fv = VERSION_ORDER[field_version]?
+      sv = VERSION_ORDER[spec_version]?
+      return false if fv.nil? || sv.nil?
+      fv > sv
+    end
+
+    # Context => { json_key => minimum_spec_version }.
+    #
+    # The contexts identify *which kind of object* the gated keys live in:
+    #   :bom       — the top-level BOM object.
+    #   :metadata  — a `metadata` object.
+    #   :component — any `component` object (top-level or nested).
+    #   :license   — a license object (the value under a `license` wrapper key).
+    #
+    # XML uses the same element names as the JSON keys for all gated fields,
+    # so the XML filter reuses this same map.
+    GATED = {
+      bom: {
+        # 1.5+
+        "annotations" => "1.5",
+        "formulation" => "1.5",
+        # 1.6+
+        "definitions"  => "1.6",
+        "declarations" => "1.6",
+      },
+      metadata: {
+        # 1.5+
+        "lifecycles" => "1.5",
+        # 1.6+ (the model only carries the deprecated `manufacture` field,
+        # which is valid in 1.4; the new `manufacturer` is listed here so the
+        # gate stays correct if it is ever added to the model).
+        "manufacturer" => "1.6",
+      },
+      component: {
+        # 1.5+
+        "modelCard" => "1.5",
+        "data"      => "1.5",
+        # 1.6+
+        "tags"             => "1.6",
+        "omniborId"        => "1.6",
+        "swhid"            => "1.6",
+        "cryptoProperties" => "1.6",
+        "manufacturer"     => "1.6",
+        # The `authors` ARRAY is 1.6+; the single `author` string is older and
+        # is intentionally NOT gated.
+        "authors" => "1.6",
+      },
+      license: {
+        # 1.6+
+        "bom-ref"         => "1.6",
+        "acknowledgement" => "1.6",
+      },
+    }
+
+    # ---- JSON filtering --------------------------------------------------
+
+    # Returns a copy of `json` (a serialized CycloneDX BOM document) with every
+    # key newer than `spec_version` removed.
+    def self.filter_json(json : String, spec_version : String) : String
+      any = JSON.parse(json)
+      filtered = filter_node(any, spec_version, :bom)
+      filtered.to_json
+    end
+
+    # Recursively filters a `JSON::Any` node. `context` is the kind of object
+    # we are currently inside (see `GATED`).
+    private def self.filter_node(node : JSON::Any, spec_version : String, context : Symbol) : JSON::Any
+      if obj = node.as_h?
+        filtered = {} of String => JSON::Any
+        gated = GATED[context]?
+        obj.each do |key, value|
+          if gated && (min = gated[key]?) && newer?(min, spec_version)
+            next # strip newer-than-declared field
+          end
+          filtered[key] = filter_child(key, value, spec_version, context)
+        end
+        JSON::Any.new(filtered)
+      elsif arr = node.as_a?
+        JSON::Any.new(arr.map { |v| filter_node(v, spec_version, context).as(JSON::Any) })
+      else
+        node
+      end
+    end
+
+    # Determines the child context when descending into `key` and recurses.
+    private def self.filter_child(key : String, value : JSON::Any, spec_version : String, context : Symbol) : JSON::Any
+      child_context =
+        case {context, key}
+        when {:bom, "metadata"}           then :metadata
+        when {:bom, "components"}         then :component
+        when {:metadata, "component"}     then :component
+        when {:component, "components"}   then :component
+        when {:component, "licenses"}     then :licenses_array
+        when {:metadata, "licenses"}      then :licenses_array
+        when {:licenses_array, "license"} then :license
+        else
+          # Stay in the current context for arrays that hold the same kind of
+          # object; otherwise enter a neutral context with no gated keys.
+          neutral_child(context, key)
+        end
+      filter_node(value, spec_version, child_context)
+    end
+
+    # Contexts whose nested objects carry the same gated keys (e.g. an array of
+    # components stays in :component) vs. anything else which becomes neutral.
+    private def self.neutral_child(context : Symbol, key : String) : Symbol
+      case context
+      when :component
+        # `components` already handled above; everything else under a component
+        # (hashes, externalReferences, ...) has no gated keys.
+        :none
+      when :licenses_array
+        # An entry of a licenses array is either a `{ "license": {...} }`
+        # wrapper or an expression object; descend keeping the array context so
+        # the `license` key is recognised.
+        :licenses_array
+      else
+        :none
+      end
+    end
+
+    # ---- XML filtering ---------------------------------------------------
+
+    # The XML filter reuses `GATED`: each gated JSON key maps to an XML element
+    # of the same name. Elements are stripped by matching the gated key against
+    # the element's parent (e.g. a `tags` element is only gated when its parent
+    # is a `component`). License-level gating is on attributes, not elements,
+    # and is handled via `XML_LICENSE_ATTRS`.
+
+    # License-level attributes that are 1.6+ only.
+    XML_LICENSE_ATTRS = {"bom-ref" => "1.6", "acknowledgement" => "1.6"}
+
+    # Returns a copy of `xml` with elements/attributes newer than
+    # `spec_version` removed.
+    def self.filter_xml(xml : String, spec_version : String) : String
+      doc = XML.parse(xml)
+      if root = doc.root
+        strip_xml(root, spec_version)
+      end
+      # Re-serialise. `to_xml` on the document includes the XML declaration to
+      # match the original `XML.build` output shape.
+      doc.to_xml(options: XML::SaveOptions::AS_XML)
+    end
+
+    private def self.strip_xml(node : XML::Node, spec_version : String) : Nil
+      # Collect children first; mutating the tree while iterating is unsafe.
+      children = node.children.select(&.element?).to_a
+
+      children.each do |child|
+        name = child.name
+
+        if gated_component_field?(name, spec_version, child)
+          child.unlink
+          next
+        end
+
+        if gated_simple_field?(name, spec_version, child)
+          child.unlink
+          next
+        end
+
+        # License-level 1.6 attributes.
+        if name == "license"
+          XML_LICENSE_ATTRS.each do |attr, min|
+            if newer?(min, spec_version) && child[attr]?
+              child.delete(attr)
+            end
+          end
+        end
+
+        strip_xml(child, spec_version)
+      end
+    end
+
+    # Component-context gated elements (modelCard/data/tags/.../authors). These
+    # are only stripped when their parent element is a `component`.
+    private def self.gated_component_field?(name : String, spec_version : String, node : XML::Node) : Bool
+      min = GATED[:component][name]?
+      return false unless min
+      parent = node.parent
+      return false unless parent && parent.element? && parent.name == "component"
+      newer?(min, spec_version)
+    end
+
+    # Non-component gated elements anchored by parent element name.
+    private def self.gated_simple_field?(name : String, spec_version : String, node : XML::Node) : Bool
+      parent = node.parent
+      return false unless parent && parent.element?
+      pname = parent.name
+
+      min =
+        case {pname, name}
+        when {"bom", "annotations"}, {"bom", "formulation"},
+             {"bom", "definitions"}, {"bom", "declarations"}
+          GATED[:bom][name]?
+        when {"metadata", "lifecycles"}, {"metadata", "manufacturer"}
+          GATED[:metadata][name]?
+        end
+
+      return false unless min
+      newer?(min, spec_version)
+    end
+
+    # ---- Validation ------------------------------------------------------
+
+    # A single field-gating violation: the JSON path of the owning object, the
+    # offending field name, and the minimum spec version that field requires.
+    record Violation, path : String, field : String, min_version : String
+
+    # Yields a `Violation` for every populated field on `bom` that is newer
+    # than `bom.spec_version`. Used by `Validator`.
+    def self.each_violation(bom, & : Violation ->) : Nil
+      violations(bom).each { |v| yield v }
+    end
+
+    # Collects all field-gating violations on `bom`.
+    def self.violations(bom) : Array(Violation)
+      sv = bom.spec_version
+      result = [] of Violation
+
+      # bom-level
+      result << Violation.new("$", "annotations", "1.5") if !bom.annotations.nil? && newer?("1.5", sv)
+      result << Violation.new("$", "formulation", "1.5") if !bom.formulation.nil? && newer?("1.5", sv)
+      result << Violation.new("$", "definitions", "1.6") if !bom.definitions.nil? && newer?("1.6", sv)
+      result << Violation.new("$", "declarations", "1.6") if !bom.declarations.nil? && newer?("1.6", sv)
+
+      if md = bom.metadata
+        result << Violation.new("$.metadata", "lifecycles", "1.5") if !md.lifecycles.nil? && newer?("1.5", sv)
+      end
+
+      bom.components.each_with_index do |comp, i|
+        collect_component_violations(comp, "$.components[#{i}]", sv, result)
+      end
+
+      if md = bom.metadata
+        if comp = md.component
+          collect_component_violations(comp, "$.metadata.component", sv, result)
+        end
+      end
+
+      result
+    end
+
+    private def self.collect_component_violations(comp, path : String, sv : String, result : Array(Violation)) : Nil
+      # field name => {present?, minimum version}
+      fields = {
+        "modelCard"        => {!comp.model_card.nil?, "1.5"},
+        "data"             => {!comp.data.nil?, "1.5"},
+        "tags"             => {!comp.tags.nil?, "1.6"},
+        "omniborId"        => {!comp.omnibor_id.nil?, "1.6"},
+        "swhid"            => {!comp.swhid.nil?, "1.6"},
+        "cryptoProperties" => {!comp.crypto_properties.nil?, "1.6"},
+        "manufacturer"     => {!comp.manufacturer.nil?, "1.6"},
+        "authors"          => {!comp.authors.nil?, "1.6"},
+      }
+      fields.each do |field, (present, min)|
+        result << Violation.new(path, field, min) if present && newer?(min, sv)
+      end
+
+      collect_license_violations(comp, path, sv, result)
+
+      if sub = comp.components
+        sub.each_with_index do |c, i|
+          collect_component_violations(c, "#{path}.components[#{i}]", sv, result)
+        end
+      end
+    end
+
+    private def self.collect_license_violations(comp, path : String, sv : String, result : Array(Violation)) : Nil
+      licenses = comp.licenses
+      return unless licenses
+
+      licenses.each_with_index do |lic, i|
+        lp = "#{path}.licenses[#{i}]"
+        result << Violation.new(lp, "bom-ref", "1.6") if !lic.bom_ref.nil? && newer?("1.6", sv)
+        result << Violation.new(lp, "acknowledgement", "1.6") if !lic.acknowledgement.nil? && newer?("1.6", sv)
+      end
+    end
+  end
+end

--- a/src/shard/shard_file.cr
+++ b/src/shard/shard_file.cr
@@ -8,8 +8,9 @@ class ShardFile
 
   # The name of the project/shard.
   getter name : String
-  # The version of the project/shard.
-  getter version : String
+  # The version of the project/shard. Optional because a `shard.yml` may omit
+  # it (e.g. an application that is never published); defaults to "unknown".
+  getter version : String = "unknown"
 
   # Optional fields
   getter description : String?

--- a/src/shard/shard_lock_file.cr
+++ b/src/shard/shard_lock_file.cr
@@ -14,8 +14,9 @@ end
 class ShardLockEntry
   include YAML::Serializable
 
-  # The version of the locked dependency.
-  getter version : String
+  # The version of the locked dependency. Optional because `path:` entries
+  # (and some other lock formats) may omit it; defaults to "unknown".
+  getter version : String = "unknown"
   # The Git URL if the dependency is sourced from a Git repository.
   getter git : String?
   # The GitHub repository path (e.g., "owner/repo") if sourced from GitHub.


### PR DESCRIPTION
## Summary
CycloneDX spec-version fidelity + robustness.

- **Version field-gating**: a new `VersionGate` strips fields newer than the declared `specVersion` from both JSON and XML, and the validator flags version-inappropriate fields. 1.5-only (`lifecycles`, `annotations`, `formulation`, `modelCard`, `data`) and 1.6-only (`definitions`, `declarations`, component `tags`/`omniborId`/`swhid`/`cryptoProperties`/`manufacturer`/`authors[]`, license `bom-ref`/`acknowledgement`) are gated. A declared-1.4/1.5 BOM can no longer emit invalid output.
- **Remove the non-existent "1.7"** spec version (no schema/validator accepts it)
- Enum validation for hash `alg` and `externalReference.type`
- Fix crash on version-less / `path:` deps; accurate YAML-error messages

276 specs green, ameba clean, `crystal build` clean. Regression tests added.
