### PR TITLE
fix: PURL encoding/canonicalization, XML XSD ordering, license & version-gate bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 ## Unreleased
 
 ### Fixed
+- PURLs are now percent-encoded per the package-url spec. Reserved characters
+  in the namespace/name and version (space, `+`, `@`, `&`, `#`, ...) are
+  encoded, so git-resolved versions like `0.1.0+git.commit.<sha>` produce a
+  valid `pkg:...@0.1.0%2Bgit.commit.<sha>` instead of a malformed PURL.
+- PURL namespace/name are lowercased for the case-insensitive `github` and
+  `bitbucket` types (e.g. `pkg:github/sysexitcode/foo`), matching the canonical
+  form used by other tooling. `gitlab` paths are case-sensitive and preserved.
+- Git URLs with a trailing slash (e.g. `https://github.com/owner/repo/`) now
+  yield a PURL instead of none.
+- GitLab subgroup git URLs (`gitlab.com/group/subgroup/repo`) now produce a
+  full-path PURL, consistent with the explicit `gitlab:` key.
+- Bitbucket git URLs now produce `pkg:bitbucket/...` PURLs.
+- A free-form license string that merely contains `AND`/`OR`/`WITH` (e.g.
+  "Free for personal OR commercial use") is no longer mis-emitted as an invalid
+  SPDX `expression`; it now falls back to a `license.name`. Only strings that
+  parse as a valid SPDX expression become a `LicenseExpression`.
+- XML element ordering now matches the CycloneDX XSD `<sequence>` for both
+  `component` (hashes/licenses before copyright/cpe/purl; pedigree before
+  externalReferences; components before evidence; releaseNotes before modelCard)
+  and `metadata` (lifecycles immediately after timestamp). Previously the output
+  could fail XSD validation.
+- Spec-version gating now strips the 1.6-only `bom-ref`/`acknowledgement` from a
+  `LicenseExpression` in both JSON and XML, so a 1.4/1.5 BOM no longer leaks
+  1.6-only fields (the `Validator` already flagged them; the filters now agree).
+- The dependency graph no longer contains a self-referential edge or duplicate
+  entries when a locked dependency shares the project's `name@version`.
+- Lock entries with an empty shard name are skipped with a warning instead of
+  emitting a schema-invalid empty-name component.
+- Stray positional arguments (e.g. a dropped dash in `spec-version 1.5`) are now
+  rejected with an error instead of being silently ignored.
 - License entries now follow the CycloneDX `LicenseChoice` shape:
   `{"license": {...}}` instead of a flat `{"id":"...","name":"..."}`.
   XML output already used `<license>...</license>` so this is a JSON-only
@@ -22,6 +52,9 @@
   as the canonical SPDX `id` (e.g. `{"license":{"id":"MIT"}}`). Free-form
   values that are not in the SPDX list still fall through to `name`.
   Backed by a new dependency on `spdx.cr`.
+- CSV output now includes the root application component (from
+  `metadata.component`) as its first row, making it consistent with the
+  JSON/XML output.
 
 ## v1.3.0
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Crystal tool for generating [CycloneDX](https://cyclonedx.org/) Software Bill 
 - Generates CycloneDX SBOMs from Crystal `shard.yml` and `shard.lock` files
 - Supports multiple output formats: JSON, XML, CSV
 - Compatible with CycloneDX spec versions 1.4, 1.5, and 1.6
-- Automatically generates Package URLs (PURLs) for dependencies
+- Automatically generates canonical, percent-encoded Package URLs (PURLs) for GitHub, GitLab, and Bitbucket dependencies
 - Docker support for containerized usage
 - Fast and lightweight implementation in Crystal
 

--- a/spec/app_integration_spec.cr
+++ b/spec/app_integration_spec.cr
@@ -4,6 +4,19 @@ require "json"
 BINARY   = "bin/cyclonedx-cr"
 FIXTURES = "spec/fixtures"
 
+# Runs the binary against the PURL-canonicalization fixture and returns a
+# name => purl map for the emitted components.
+private def canon_purls : Hash(String, String)
+  output = `#{BINARY} -s #{FIXTURES}/minimal_shard.yml -i #{FIXTURES}/purl_canon_lock.lock 2>&1`
+  result = {} of String => String
+  JSON.parse(output)["components"].as_a.each do |c|
+    if purl = c["purl"]?
+      result[c["name"].as_s] = purl.as_s
+    end
+  end
+  result
+end
+
 describe "App Integration" do
   describe "CLI argument parsing" do
     it "shows help with -h" do
@@ -153,12 +166,15 @@ describe "App Integration" do
   end
 
   describe "CSV output" do
-    it "generates CSV with header and components" do
+    it "generates CSV with header, root component, and dependencies" do
       output = `#{BINARY} -s #{FIXTURES}/shard.yml -i #{FIXTURES}/shard.lock --output-format csv 2>&1`
       $?.success?.should be_true
       lines = output.strip.split("\n")
       lines[0].should eq("Name,Version,PURL,Type")
-      lines.size.should eq(3) # header + 2 dependencies
+      lines.size.should eq(4) # header + root application + 2 dependencies
+      # The root application component (from metadata.component) is included so
+      # the CSV is consistent with the JSON/XML output.
+      output.should contain("test-app,0.1.0,,application")
     end
   end
 
@@ -254,6 +270,72 @@ describe "App Integration" do
       license = component["licenses"].as_a[0]["license"]
       license["name"].should eq("Proprietary")
       license["id"]?.should be_nil
+    end
+
+    it "does NOT treat a free-form string containing OR as an SPDX expression" do
+      # "Free for personal OR commercial use" contains "OR" but is not a valid
+      # SPDX expression, so it must fall back to the free-form license name.
+      output = `#{BINARY} -s #{FIXTURES}/freeform_or_license_shard.yml -i #{FIXTURES}/empty_lock.lock 2>&1`
+      $?.success?.should be_true
+      component = JSON.parse(output)["metadata"]["component"]
+      licenses = component["licenses"].as_a
+      licenses.size.should eq(1)
+      licenses[0]["expression"]?.should be_nil
+      licenses[0]["license"]["name"].should eq("Free for personal OR commercial use")
+    end
+  end
+
+  describe "PURL canonicalization and encoding" do
+    it "lowercases the namespace/name for github (case-insensitive type)" do
+      canon_purls["gh_upper"].should eq("pkg:github/sysexitcode/foo@1.0.0")
+    end
+
+    it "still produces a PURL when a git URL has a trailing slash" do
+      canon_purls["gh_trailing"].should eq("pkg:github/owner/repo@1.2.3")
+    end
+
+    it "percent-encodes reserved characters in the version" do
+      # '+' build metadata must be encoded as %2B per the PURL spec.
+      canon_purls["gh_buildmeta"].should eq("pkg:github/hahwul/spdx.cr@0.1.0%2Bgit.commit.abc")
+    end
+
+    it "emits a pkg:bitbucket PURL for bitbucket git URLs (lowercased)" do
+      canon_purls["bb_url"].should eq("pkg:bitbucket/team/proj@3.0.0")
+    end
+
+    it "captures the full path for gitlab subgroup git URLs" do
+      canon_purls["gl_subgroup"].should eq("pkg:gitlab/group/subgroup/repo@1.1.1")
+    end
+
+    it "preserves case for gitlab (case-sensitive type)" do
+      canon_purls["gl_key"].should eq("pkg:gitlab/MyOrg/MyLib@2.0.0")
+    end
+  end
+
+  describe "robustness" do
+    it "rejects stray positional arguments" do
+      output = `#{BINARY} -s #{FIXTURES}/shard.yml -i #{FIXTURES}/shard.lock stray 2>&1`
+      $?.success?.should be_false
+      output.should contain("Unexpected argument")
+    end
+
+    it "skips lock entries with an empty shard name" do
+      output = `#{BINARY} -s #{FIXTURES}/minimal_shard.yml -i #{FIXTURES}/empty_name_lock.lock 2>&1`
+      $?.success?.should be_true
+      output.should contain("empty shard name")
+      bom = JSON.parse(output.lines.reject(&.starts_with?("Warning")).join("\n"))
+      names = bom["components"].as_a.map(&.["name"].as_s)
+      names.should eq(["good"])
+    end
+
+    it "does not emit a self-referential dependency edge on a name@version collision" do
+      output = `#{BINARY} -s #{FIXTURES}/self_dep_shard.yml -i #{FIXTURES}/self_dep_lock.lock 2>&1`
+      $?.success?.should be_true
+      deps = JSON.parse(output)["dependencies"].as_a
+      root = deps.find!(&.["ref"].as_s.== "dup@9.9.9")
+      root["dependsOn"].as_a.should be_empty
+      # the same ref must not appear as more than one top-level dependency entry
+      deps.count(&.["ref"].as_s.== "dup@9.9.9").should eq(1)
     end
   end
 end

--- a/spec/app_integration_spec.cr
+++ b/spec/app_integration_spec.cr
@@ -310,11 +310,25 @@ describe "App Integration" do
     it "preserves case for gitlab (case-sensitive type)" do
       canon_purls["gl_key"].should eq("pkg:gitlab/MyOrg/MyLib@2.0.0")
     end
+
+    it "does not leak an explicit port from an ssh github URL into the PURL" do
+      canon_purls["gh_ssh_port"].should eq("pkg:github/owner/repo@4.0.0")
+    end
+
+    it "does not leak an explicit port from a gitlab URL into the PURL namespace" do
+      canon_purls["gl_port"].should eq("pkg:gitlab/group/repo@5.0.0")
+    end
   end
 
   describe "robustness" do
     it "rejects stray positional arguments" do
       output = `#{BINARY} -s #{FIXTURES}/shard.yml -i #{FIXTURES}/shard.lock stray 2>&1`
+      $?.success?.should be_false
+      output.should contain("Unexpected argument")
+    end
+
+    it "rejects a bare dash argument" do
+      output = `#{BINARY} -s #{FIXTURES}/shard.yml -i #{FIXTURES}/shard.lock - 2>&1`
       $?.success?.should be_false
       output.should contain("Unexpected argument")
     end

--- a/spec/cyclonedx/component_spec.cr
+++ b/spec/cyclonedx/component_spec.cr
@@ -125,20 +125,27 @@ describe CycloneDX::Component do
       xml_content.should contain %(<url>https://github.com/example/xml-lib</url>)
     end
 
-    it "outputs purl before hashes in XML (spec order)" do
+    it "outputs hashes and licenses before copyright/cpe/purl in XML (XSD sequence order)" do
+      # Per the CycloneDX componentType XSD <sequence>, hashes and licenses
+      # precede copyright, cpe and purl. (The previous version of this test
+      # asserted the reverse, which was an XSD-invalid ordering.)
       hashes = [CycloneDX::Hash.new(algorithm: "SHA-256", content: "abc123")]
+      licenses = [CycloneDX::License.new(name: "MIT")] of CycloneDX::License | CycloneDX::LicenseExpression
       component = CycloneDX::Component.new(
         name: "lib", version: "1.0.0",
         purl: "pkg:github/owner/lib@1.0.0",
         cpe: "cpe:2.3:a:owner:lib:1.0.0",
         hashes: hashes,
+        licenses: licenses,
       )
       xml_content = XML.build(indent: "  ") do |xml|
         component.to_xml(xml)
       end
-      purl_pos = xml_content.index!("<purl>")
       hashes_pos = xml_content.index!("<hashes>")
-      purl_pos.should be < hashes_pos
+      licenses_pos = xml_content.index!("<licenses>")
+      purl_pos = xml_content.index!("<purl>")
+      hashes_pos.should be < purl_pos
+      licenses_pos.should be < purl_pos
     end
 
     it "handles optional fields being nil in XML" do
@@ -172,6 +179,22 @@ describe CycloneDX::Component do
 
       xml_content.should contain %(<properties>)
       xml_content.should contain %(<property name="cdx:tool:name">test</property>)
+    end
+
+    it "serializes component.data as repeated <data> elements (XSD componentDataType)" do
+      component = CycloneDX::Component.new(
+        name: "ml", version: "1.0.0",
+        data: [CycloneDX::ComponentData.new(data_type: "dataset", name: "training-set")],
+      )
+      xml_content = XML.build(indent: "  ") do |xml|
+        component.to_xml(xml)
+      end
+      # The componentDataType element is <data> directly, not a <data> wrapper
+      # around <dataset> (that legacy shape failed XSD validation).
+      xml_content.should contain %(<data>)
+      xml_content.should contain %(<type>dataset</type>)
+      xml_content.should contain %(<name>training-set</name>)
+      xml_content.should_not contain %(<dataset>)
     end
   end
 

--- a/spec/cyclonedx/metadata_spec.cr
+++ b/spec/cyclonedx/metadata_spec.cr
@@ -143,6 +143,26 @@ describe CycloneDX::Metadata do
       xml_string.should contain("<name>Sup Corp</name>")
     end
 
+    it "emits lifecycles immediately after timestamp and before tools (XSD order)" do
+      lc = CycloneDX::Lifecycle.new(phase: "build")
+      tool = CycloneDX::Tool.new(name: "t")
+      metadata = CycloneDX::Metadata.new(
+        timestamp: "2024-01-01T00:00:00Z", lifecycles: [lc], tools: [tool]
+      )
+
+      io = IO::Memory.new
+      xml = XML::Builder.new(io)
+      metadata.to_xml(xml)
+      xml.flush
+      xml_string = io.to_s
+
+      ts_pos = xml_string.index!("<timestamp>")
+      lc_pos = xml_string.index!("<lifecycles>")
+      tools_pos = xml_string.index!("<tools>")
+      ts_pos.should be < lc_pos
+      lc_pos.should be < tools_pos
+    end
+
     it "serializes properties to XML" do
       props = [CycloneDX::Property.new(name: "cdx:tool:name", value: "test")]
       metadata = CycloneDX::Metadata.new(properties: props)

--- a/spec/cyclonedx/version_gate_spec.cr
+++ b/spec/cyclonedx/version_gate_spec.cr
@@ -36,6 +36,19 @@ private def core_bom(version : String) : CycloneDX::BOM
   CycloneDX::BOM.new([dep], version, metadata: md, dependencies: graph)
 end
 
+# Builds a one-component BOM whose only license is a `LicenseExpression`
+# carrying the 1.6-only `bom-ref` and `acknowledgement` fields.
+private def expr_bom(version : String) : CycloneDX::BOM
+  expr = CycloneDX::LicenseExpression.new(
+    expression: "MIT OR Apache-2.0", bom_ref: "expr-1", acknowledgement: "concluded"
+  )
+  comp = CycloneDX::Component.new(
+    name: "lib", version: "1.0",
+    licenses: [expr] of CycloneDX::License | CycloneDX::LicenseExpression
+  )
+  CycloneDX::BOM.new([comp], version)
+end
+
 describe CycloneDX::VersionGate do
   describe "(a) metadata.lifecycles / bom.annotations gating" do
     it "does NOT emit lifecycles or annotations when declared as 1.4" do
@@ -227,6 +240,35 @@ describe CycloneDX::VersionGate do
       bom = CycloneDX::BOM.new([comp], "1.4")
       validator = CycloneDX::Validator.new
       validator.validate(bom).should be_true
+    end
+  end
+
+  describe "(f) LicenseExpression bom-ref/acknowledgement gating (1.6+)" do
+    it "strips bom-ref/acknowledgement from a LicenseExpression in 1.4 JSON" do
+      json = expr_bom("1.4").to_json
+      json.should contain(%("expression":"MIT OR Apache-2.0"))
+      json.should_not contain(%("bom-ref":"expr-1"))
+      json.should_not contain(%("acknowledgement"))
+    end
+
+    it "strips bom-ref/acknowledgement attributes from an <expression> in 1.4 XML" do
+      xml = expr_bom("1.4").to_xml
+      xml.should contain("MIT OR Apache-2.0")
+      xml.should_not contain(%(bom-ref="expr-1"))
+      xml.should_not contain("acknowledgement")
+    end
+
+    it "keeps bom-ref/acknowledgement on a LicenseExpression in 1.6 JSON" do
+      json = expr_bom("1.6").to_json
+      json.should contain(%("bom-ref":"expr-1"))
+      json.should contain(%("acknowledgement":"concluded"))
+    end
+
+    it "reports validator violations that the filters actually strip (consistency)" do
+      validator = CycloneDX::Validator.new
+      validator.validate(expr_bom("1.4")).should be_false
+      validator.errors.any?(&.path.includes?("bom-ref")).should be_true
+      validator.errors.any?(&.path.includes?("acknowledgement")).should be_true
     end
   end
 end

--- a/spec/fixtures/empty_name_lock.lock
+++ b/spec/fixtures/empty_name_lock.lock
@@ -1,0 +1,8 @@
+version: 2.0
+shards:
+  "":
+    github: owner/blank
+    version: 1.0.0
+  good:
+    github: owner/good
+    version: 2.0.0

--- a/spec/fixtures/freeform_or_license_shard.yml
+++ b/spec/fixtures/freeform_or_license_shard.yml
@@ -1,0 +1,3 @@
+name: freeform
+version: 1.0.0
+license: Free for personal OR commercial use

--- a/spec/fixtures/purl_canon_lock.lock
+++ b/spec/fixtures/purl_canon_lock.lock
@@ -1,0 +1,20 @@
+version: 2.0
+shards:
+  gh_upper:
+    github: SysExitCode/Foo
+    version: 1.0.0
+  gh_trailing:
+    git: https://github.com/Owner/Repo/
+    version: 1.2.3
+  gh_buildmeta:
+    github: hahwul/spdx.cr
+    version: "0.1.0+git.commit.abc"
+  bb_url:
+    git: https://bitbucket.org/Team/Proj.git
+    version: 3.0.0
+  gl_subgroup:
+    git: https://gitlab.com/group/subgroup/repo.git
+    version: 1.1.1
+  gl_key:
+    gitlab: MyOrg/MyLib
+    version: 2.0.0

--- a/spec/fixtures/purl_canon_lock.lock
+++ b/spec/fixtures/purl_canon_lock.lock
@@ -18,3 +18,9 @@ shards:
   gl_key:
     gitlab: MyOrg/MyLib
     version: 2.0.0
+  gh_ssh_port:
+    git: ssh://git@github.com:22/Owner/Repo.git
+    version: 4.0.0
+  gl_port:
+    git: https://gitlab.com:8080/group/repo.git
+    version: 5.0.0

--- a/spec/fixtures/self_dep_lock.lock
+++ b/spec/fixtures/self_dep_lock.lock
@@ -1,0 +1,5 @@
+version: 2.0
+shards:
+  dup:
+    github: owner/dup
+    version: 9.9.9

--- a/spec/fixtures/self_dep_shard.yml
+++ b/spec/fixtures/self_dep_shard.yml
@@ -1,0 +1,2 @@
+name: dup
+version: 9.9.9

--- a/src/app.cr
+++ b/src/app.cr
@@ -1,4 +1,5 @@
 require "option_parser"
+require "uri"
 require "spdx"
 require "./cyclonedx/bom"
 require "./cyclonedx/component"
@@ -23,13 +24,18 @@ class App
   REF_TYPE_VCS               = "vcs"
   PURL_GITHUB_PREFIX         = "pkg:github/"
   PURL_GITLAB_PREFIX         = "pkg:gitlab/"
+  PURL_BITBUCKET_PREFIX      = "pkg:bitbucket/"
 
   SCOPE_REQUIRED = "required"
   SCOPE_OPTIONAL = "optional"
 
-  # Regex patterns for extracting owner/repo from Git URLs
-  private GITHUB_REPO_PATTERN = /github\.com[\/:]([^\/]+\/[^\/]+?)(?:\.git)?$/
-  private GITLAB_REPO_PATTERN = /gitlab\.com[\/:]([^\/]+\/[^\/]+?)(?:\.git)?$/
+  # Regex patterns for extracting owner/repo from Git URLs.
+  # A trailing `.git` suffix and any trailing slashes are tolerated. GitHub and
+  # Bitbucket repos are exactly `owner/repo`; GitLab additionally supports
+  # subgroups (`group/subgroup/.../repo`), so its pattern captures the full path.
+  private GITHUB_REPO_PATTERN    = /github\.com[\/:]([^\/]+\/[^\/]+?)(?:\.git)?\/*$/
+  private GITLAB_REPO_PATTERN    = /gitlab\.com[\/:]([^\/].*?)(?:\.git)?\/*$/
+  private BITBUCKET_REPO_PATTERN = /bitbucket\.org[\/:]([^\/]+\/[^\/]+?)(?:\.git)?\/*$/
 
   # Holds parsed command-line options.
   record Options,
@@ -77,6 +83,18 @@ class App
         STDERR.puts "Error: Missing value for option '#{flag}'."
         STDERR.puts parser
         exit(1)
+      end
+      parser.unknown_args do |before, after|
+        # Unrecognised flags also appear here, but they are reported by
+        # `invalid_option`; only genuine positional arguments (which this tool
+        # never accepts) are flagged here so a dropped dash like
+        # `spec-version 1.5` is not silently ignored.
+        positionals = (before + after).reject(&.starts_with?('-'))
+        unless positionals.empty?
+          STDERR.puts "Error: Unexpected argument(s): #{positionals.join(", ")}. This tool takes options only."
+          STDERR.puts parser
+          exit(1)
+        end
       end
     end
 
@@ -202,11 +220,15 @@ class App
 
   # Build a licenses array for a shard.yml license field.
   #
-  # - Compound expressions (containing AND/OR/WITH) become LicenseExpression.
+  # - Strings that contain an AND/OR/WITH operator AND parse as a valid SPDX
+  #   expression become a LicenseExpression. The validity check matters: a
+  #   free-form string like "Free for personal OR commercial use" contains
+  #   "OR" but is not a license expression, so it must NOT be emitted as one
+  #   (an invalid `expression` fails CycloneDX/SPDX validation).
   # - Single identifiers that exist in the SPDX catalog use the canonical `id`.
-  # - Identifiers not in the SPDX catalog fall back to `name`.
+  # - Everything else falls back to the free-form `name`.
   private def build_licenses(license : String) : Array(CycloneDX::License | CycloneDX::LicenseExpression)
-    if license =~ SPDX_EXPRESSION_PATTERN
+    if license =~ SPDX_EXPRESSION_PATTERN && Spdx.valid_expression?(license)
       [CycloneDX::LicenseExpression.new(expression: license)] of CycloneDX::License | CycloneDX::LicenseExpression
     elsif Spdx.license?(license)
       canonical = Spdx.find_license(license).id
@@ -247,7 +269,14 @@ class App
   private def parse_dependencies(file_path : String, dev_dep_names : Set(String)) : Array(CycloneDX::Component)
     lock_file = read_yaml_file(file_path, ShardLockFile)
 
-    lock_file.shards.map do |name, details|
+    lock_file.shards.compact_map do |name, details|
+      # A component name is required and must be non-empty; an empty/blank lock
+      # key would yield a schema-invalid component, so skip it with a warning.
+      if name.blank?
+        STDERR.puts "Warning: skipping lock entry with an empty shard name."
+        next
+      end
+
       scope = dev_dep_names.includes?(name) ? SCOPE_OPTIONAL : SCOPE_REQUIRED
 
       CycloneDX::Component.new(
@@ -265,18 +294,25 @@ class App
   # Each dependency has an empty dependsOn list (transitive deps not available from shard.lock).
   private def build_dependency_graph(main_component : CycloneDX::Component,
                                      dependencies : Array(CycloneDX::Component)) : Array(CycloneDX::Dependency)
-    dep_refs = dependencies.compact_map(&.bom_ref)
-
     graph = [] of CycloneDX::Dependency
+    seen = Set(String).new
 
-    # Main component depends on all dependencies
-    if main_ref = main_component.bom_ref
+    main_ref = main_component.bom_ref
+
+    # Main component depends on all dependencies. De-duplicate the refs and drop
+    # the main component's own ref so the graph never contains a self-edge (this
+    # can happen if a locked dependency shares the project's name@version).
+    if main_ref
+      dep_refs = dependencies.compact_map(&.bom_ref).reject { |r| r == main_ref }.uniq!
       graph << CycloneDX::Dependency.new(ref: main_ref, depends_on: dep_refs)
+      seen << main_ref
     end
 
-    # Each dependency listed with empty dependsOn
+    # Each dependency listed once with an empty dependsOn.
     dependencies.each do |dep|
       if ref = dep.bom_ref
+        next if seen.includes?(ref)
+        seen << ref
         graph << CycloneDX::Dependency.new(ref: ref)
       end
     end
@@ -285,23 +321,53 @@ class App
   end
 
   # Generates a Package URL (PURL) for a given shard based on its details.
-  # Supports GitHub and GitLab repositories.
+  # Supports GitHub, GitLab and (via Git URL) Bitbucket repositories.
   private def generate_purl(details : ShardLockEntry) : String?
     if github_repo = details.github
-      "#{PURL_GITHUB_PREFIX}#{github_repo}@#{details.version}"
+      build_purl(PURL_GITHUB_PREFIX, github_repo, details.version, lowercase: true)
     elsif gitlab_repo = details.gitlab
-      "#{PURL_GITLAB_PREFIX}#{gitlab_repo}@#{details.version}"
+      build_purl(PURL_GITLAB_PREFIX, gitlab_repo, details.version, lowercase: false)
     elsif git_url = details.git
       parse_purl_from_git_url(git_url, details.version)
     end
   end
 
-  # Extracts a PURL from a Git URL by matching known hosts (GitHub, GitLab).
+  # Extracts a PURL from a Git URL by matching known hosts (GitHub, GitLab,
+  # Bitbucket). Returns nil for unrecognised hosts.
   private def parse_purl_from_git_url(git_url : String, version : String) : String?
     if git_url =~ GITHUB_REPO_PATTERN
-      "#{PURL_GITHUB_PREFIX}#{$1}@#{version}"
+      build_purl(PURL_GITHUB_PREFIX, $1, version, lowercase: true)
     elsif git_url =~ GITLAB_REPO_PATTERN
-      "#{PURL_GITLAB_PREFIX}#{$1}@#{version}"
+      build_purl(PURL_GITLAB_PREFIX, $1, version, lowercase: false)
+    elsif git_url =~ BITBUCKET_REPO_PATTERN
+      build_purl(PURL_BITBUCKET_PREFIX, $1, version, lowercase: true)
     end
+  end
+
+  # Assembles a canonical PURL from a repo path ("owner/repo", or for GitLab a
+  # longer "group/subgroup/repo") and a version.
+  #
+  # Per the package-url spec every component is percent-encoded so reserved
+  # characters (space, '+', '@', '&', '#', ...) cannot corrupt the PURL grammar.
+  # The github and bitbucket types define the namespace/name as case-insensitive
+  # and require it lowercased; gitlab paths are case-sensitive and left as-is.
+  # The version is always percent-encoded but never case-folded.
+  private def build_purl(prefix : String, repo_path : String, version : String, lowercase : Bool) : String
+    repo_path = repo_path.downcase if lowercase
+    "#{prefix}#{encode_purl_path(repo_path)}@#{encode_purl_segment(version)}"
+  end
+
+  # Percent-encodes a single PURL component. `URI.encode_path_segment` leaves
+  # exactly the PURL unreserved set (A-Z a-z 0-9 . - _ ~) untouched and encodes
+  # everything else, which matches the spec's component encoding rules.
+  private def encode_purl_segment(value : String) : String
+    URI.encode_path_segment(value)
+  end
+
+  # Percent-encodes a "namespace/name" path one slash-delimited segment at a
+  # time so the '/' separators are preserved while reserved characters inside
+  # each segment are still encoded.
+  private def encode_purl_path(path : String) : String
+    path.split('/').map { |segment| encode_purl_segment(segment) }.join('/')
   end
 end

--- a/src/app.cr
+++ b/src/app.cr
@@ -30,12 +30,17 @@ class App
   SCOPE_OPTIONAL = "optional"
 
   # Regex patterns for extracting owner/repo from Git URLs.
+  #
+  # The host may be followed by an explicit `:<port>/` (e.g. an
+  # `ssh://git@github.com:22/owner/repo` remote); that port must be consumed,
+  # not captured as part of the namespace. `(?::\d+\/|[\/:])` matches either a
+  # `:port/` or the ordinary `/` (scheme URL) / `:` (scp-form) separator.
   # A trailing `.git` suffix and any trailing slashes are tolerated. GitHub and
   # Bitbucket repos are exactly `owner/repo`; GitLab additionally supports
   # subgroups (`group/subgroup/.../repo`), so its pattern captures the full path.
-  private GITHUB_REPO_PATTERN    = /github\.com[\/:]([^\/]+\/[^\/]+?)(?:\.git)?\/*$/
-  private GITLAB_REPO_PATTERN    = /gitlab\.com[\/:]([^\/].*?)(?:\.git)?\/*$/
-  private BITBUCKET_REPO_PATTERN = /bitbucket\.org[\/:]([^\/]+\/[^\/]+?)(?:\.git)?\/*$/
+  private GITHUB_REPO_PATTERN    = /github\.com(?::\d+\/|[\/:])([^\/]+\/[^\/]+?)(?:\.git)?\/*$/
+  private GITLAB_REPO_PATTERN    = /gitlab\.com(?::\d+\/|[\/:])([^\/].*?)(?:\.git)?\/*$/
+  private BITBUCKET_REPO_PATTERN = /bitbucket\.org(?::\d+\/|[\/:])([^\/]+\/[^\/]+?)(?:\.git)?\/*$/
 
   # Holds parsed command-line options.
   record Options,
@@ -85,11 +90,13 @@ class App
         exit(1)
       end
       parser.unknown_args do |before, after|
-        # Unrecognised flags also appear here, but they are reported by
-        # `invalid_option`; only genuine positional arguments (which this tool
-        # never accepts) are flagged here so a dropped dash like
+        # Unrecognised flags (e.g. `--foo`, `-x`) also appear here, but they are
+        # reported by `invalid_option`, so they are filtered out to avoid
+        # double-reporting. A bare `-` is NOT routed to `invalid_option`, so it
+        # is kept and flagged here; genuine positional arguments (which this tool
+        # never accepts) are likewise flagged so a dropped dash like
         # `spec-version 1.5` is not silently ignored.
-        positionals = (before + after).reject(&.starts_with?('-'))
+        positionals = (before + after).reject { |arg| arg.starts_with?('-') && arg != "-" }
         unless positionals.empty?
           STDERR.puts "Error: Unexpected argument(s): #{positionals.join(", ")}. This tool takes options only."
           STDERR.puts parser

--- a/src/cyclonedx/bom.cr
+++ b/src/cyclonedx/bom.cr
@@ -165,9 +165,16 @@ class CycloneDX::BOM
   end
 
   # Serializes the BOM to CSV format.
+  #
+  # The root component lives in `metadata.component` (not in `components`), so it
+  # is emitted as the first row to keep the CSV consistent with the JSON/XML
+  # output, which both represent the root component.
   def to_csv : String
     CSV.build do |csv|
       csv.row "Name", "Version", "PURL", "Type"
+      if root = @metadata.try(&.component)
+        csv.row root.name, root.version, root.purl, root.component_type
+      end
       @components.each do |component|
         csv.row component.name, component.version, component.purl, component.component_type
       end

--- a/src/cyclonedx/component.cr
+++ b/src/cyclonedx/component.cr
@@ -114,13 +114,11 @@ class CycloneDX::Component
       if scope_val = @scope
         xml.element("scope") { xml.text(scope_val) }
       end
-      if copyright = @copyright
-        xml.element("copyright") { xml.text(copyright) }
-      end
-      @cpe.try { |cpe| xml.element("cpe") { xml.text(cpe) } }
-      @purl.try { |purl| xml.element("purl") { xml.text(purl) } }
-      @swid.try(&.to_xml(xml))
-
+      # Element order below follows the CycloneDX componentType XSD <sequence>:
+      # ... scope, hashes, licenses, copyright, cpe, purl, swid, pedigree,
+      # externalReferences, properties, components, evidence, releaseNotes,
+      # modelCard, data, cryptoProperties, tags. Emitting out of this order
+      # makes the document fail XSD validation.
       if hashes_val = @hashes
         xml.element("hashes") do
           hashes_val.each(&.to_xml(xml))
@@ -132,6 +130,14 @@ class CycloneDX::Component
           licenses_val.each(&.to_xml(xml))
         end
       end
+
+      if copyright = @copyright
+        xml.element("copyright") { xml.text(copyright) }
+      end
+      @cpe.try { |cpe| xml.element("cpe") { xml.text(cpe) } }
+      @purl.try { |purl| xml.element("purl") { xml.text(purl) } }
+      @swid.try(&.to_xml(xml))
+      @pedigree.try(&.to_xml(xml))
 
       if external_refs_val = @external_references
         xml.element("externalReferences") do
@@ -145,25 +151,23 @@ class CycloneDX::Component
         end
       end
 
-      @pedigree.try(&.to_xml(xml))
-      @evidence.try(&.to_xml(xml))
-
       if sub_components = @components
         xml.element("components") do
           sub_components.each(&.to_xml(xml))
         end
       end
 
+      @evidence.try(&.to_xml(xml))
+      @release_notes.try(&.to_xml(xml))
       @model_card.try(&.to_xml(xml))
 
+      # Each ComponentData is its own `<data>` element (componentDataType,
+      # maxOccurs unbounded) — not a `<data>` wrapper around `<dataset>` items.
       if data_val = @data
-        xml.element("data") do
-          data_val.each(&.to_xml(xml))
-        end
+        data_val.each(&.to_xml(xml, "data"))
       end
 
       @crypto_properties.try(&.to_xml(xml))
-      @release_notes.try(&.to_xml(xml))
 
       if tags_val = @tags
         xml.element("tags") do

--- a/src/cyclonedx/metadata.cr
+++ b/src/cyclonedx/metadata.cr
@@ -23,9 +23,17 @@ module CycloneDX
     end
 
     def to_xml(xml : XML::Builder)
+      # Element order follows the CycloneDX metadataType XSD <sequence>:
+      # timestamp, lifecycles, tools, authors, component, manufacturer,
+      # manufacture, supplier, licenses, properties.
       xml.element("metadata") do
         if ts = @timestamp
           xml.element("timestamp") { xml.text ts }
+        end
+        if lifecycles_val = @lifecycles
+          xml.element("lifecycles") do
+            lifecycles_val.each(&.to_xml(xml))
+          end
         end
         if tools_val = @tools
           xml.element("tools") do
@@ -40,11 +48,6 @@ module CycloneDX
         @component.try(&.to_xml(xml))
         @manufacture.try(&.to_xml(xml, "manufacture"))
         @supplier.try(&.to_xml(xml, "supplier"))
-        if lifecycles_val = @lifecycles
-          xml.element("lifecycles") do
-            lifecycles_val.each(&.to_xml(xml))
-          end
-        end
 
         if props = @properties
           xml.element("properties") do

--- a/src/cyclonedx/models.cr
+++ b/src/cyclonedx/models.cr
@@ -929,12 +929,15 @@ module CycloneDX
                    @description : String? = nil, @bom_ref : String? = nil)
     end
 
-    def to_xml(xml : XML::Builder)
+    # `element_name` differs by context: a `componentDataType` is named
+    # `<data>` directly under a component, but `<dataset>` inside a model card's
+    # `<datasets>` collection.
+    def to_xml(xml : XML::Builder, element_name : String = "dataset")
       attrs = {} of String => String
       if bom_ref_val = @bom_ref
         attrs["bom-ref"] = bom_ref_val
       end
-      xml.element("dataset", attributes: attrs) do
+      xml.element(element_name, attributes: attrs) do
         if dt = @data_type
           xml.element("type") { xml.text dt }
         end

--- a/src/cyclonedx/version_gate.cr
+++ b/src/cyclonedx/version_gate.cr
@@ -79,6 +79,15 @@ module CycloneDX
         "bom-ref"         => "1.6",
         "acknowledgement" => "1.6",
       },
+      # A `LicenseExpression` sits directly in a licenses array (no `license`
+      # wrapper key), so its 1.6+ `bom-ref`/`acknowledgement` keys are gated at
+      # the array-entry level. The `{ "license": {...} }` wrapper carries only
+      # the `license` key here, so it is unaffected.
+      licenses_array: {
+        # 1.6+
+        "bom-ref"         => "1.6",
+        "acknowledgement" => "1.6",
+      },
     }
 
     # ---- JSON filtering --------------------------------------------------
@@ -188,8 +197,9 @@ module CycloneDX
           next
         end
 
-        # License-level 1.6 attributes.
-        if name == "license"
+        # License-level 1.6 attributes. These live on both the `<license>`
+        # wrapper element and a bare `<expression>` element (a LicenseExpression).
+        if name == "license" || name == "expression"
           XML_LICENSE_ATTRS.each do |attr, min|
             if newer?(min, spec_version) && child[attr]?
               child.delete(attr)


### PR DESCRIPTION
## Summary

Analyzed the tool, ran it across many inputs, and hunted bugs with a multi-agent adversarial workflow. Every output now validates against the **real CycloneDX 1.4/1.5/1.6 XSD** (`xmllint`) and the **1.6 JSON schema** (`jsonschema`).

## Bugs fixed

### PURL — `src/app.cr` (highest impact)
- **Not percent-encoded.** Namespace/name and version were interpolated raw, so reserved chars (space, `+`, `@`, `&`, `#`) produced malformed PURLs. Notably `shards` writes git-resolved versions as `X.Y.Z+git.commit.<sha>`, so this fired on everyday input. Now encoded per the package-url spec via per-segment `URI.encode_path_segment` (e.g. `…@0.1.0%2Bgit.commit.<sha>`).
- **No case normalization.** `SysExitCode/Foo` → now `pkg:github/sysexitcode/foo`. github & bitbucket are case-insensitive and must be lowercased; **gitlab is left case-sensitive** (the spec defines no lowercasing for gitlab — deliberate, documented in a comment).
- Trailing-slash git URLs now yield a PURL; gitlab **subgroups** (`group/subgroup/repo`) captured; **bitbucket** git URLs now supported (`pkg:bitbucket/…`).

### License classification — `src/app.cr`
- A free-form string merely containing `AND`/`OR`/`WITH` (e.g. `"Free for personal OR commercial use"`) was emitted as an invalid SPDX `expression`. Now gated behind `Spdx.valid_expression?`; otherwise falls back to `license.name`.

### XML serialization — `component.cr`, `metadata.cr`, `models.cr`
- Element order did **not** match the CycloneDX XSD `<sequence>` (e.g. hashes/licenses after copyright/cpe/purl; lifecycles last in metadata) → documents failed XSD validation. Reordered to the XSD.
- `component.data` was serialized as `<data><dataset>…` instead of repeated `<data>` elements (`componentDataType`). Fixed.

### Spec-version gating — `version_gate.cr`
- 1.6-only `bom-ref`/`acknowledgement` survived on a `LicenseExpression` in 1.4/1.5 JSON **and** XML output. Now stripped in both; the `Validator` and the serialization filters are consistent.

### Robustness — `app.cr`, `bom.cr`
- Dependency graph no longer emits a self-referential edge or duplicate entries on a `name@version` collision.
- Lock entries with an empty shard name are skipped with a warning (was a schema-invalid empty-name component).
- Stray positional args are rejected (a dropped dash in `spec-version 1.5` was silently ignored → wrong-but-valid default output).
- CSV now includes the root application component, consistent with JSON/XML.

## Verification
- **292 specs pass** (+16 new), **ameba clean**.
- `xmllint --schema` against `bom-1.4/1.5/1.6.xsd` — simple, rich, and down-gated BOMs all validate.
- `jsonschema` against `bom-1.6.schema.json` — self-SBOM and percent-encoded-PURL outputs validate.

See `CHANGELOG.md` for the itemized list.

## Intentionally not changed
- CSV formula-injection defanging (prefixing `=`/`+`/`-`/`@`) — would mutate data and is not done by Syft/cdxgen; left as-is.