### PR TITLE
ci(homebrew): ship a prebuilt-binary formula via the tap

### DIFF
--- a/.github/homebrew/cyclonedx-cr.rb.tmpl
+++ b/.github/homebrew/cyclonedx-cr.rb.tmpl
@@ -1,0 +1,45 @@
+# typed: strict
+# frozen_string_literal: true
+
+# This file is rendered by cyclonedx-cr's release pipeline (.github/workflows/publish-homebrew-tap.yml).
+# DO NOT EDIT by hand.
+class CyclonedxCr < Formula
+  desc "CycloneDX SBOM generator for Crystal projects (shard.yml/shard.lock)"
+  homepage "https://github.com/hahwul/cyclonedx-cr"
+  version "__VERSION__"
+  license "MIT"
+
+  # cyclonedx-cr ships prebuilt binaries: Linux is statically linked (musl) and
+  # macOS links only system libraries (system libxml2) plus statically linked
+  # Crystal runtime libs and libyaml, so the formula declares no dependencies.
+  # An otool guard in release-binary.yml enforces that no Homebrew dylib leaks in.
+  on_macos do
+    on_arm do
+      url "https://github.com/hahwul/cyclonedx-cr/releases/download/v__VERSION__/cyclonedx-cr-v__VERSION__-osx-arm64"
+      sha256 "__SHA_OSX_ARM64__"
+    end
+    on_intel do
+      url "https://github.com/hahwul/cyclonedx-cr/releases/download/v__VERSION__/cyclonedx-cr-v__VERSION__-osx-x86_64"
+      sha256 "__SHA_OSX_X86_64__"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/hahwul/cyclonedx-cr/releases/download/v__VERSION__/cyclonedx-cr-v__VERSION__-linux-arm64"
+      sha256 "__SHA_LINUX_ARM64__"
+    end
+    on_intel do
+      url "https://github.com/hahwul/cyclonedx-cr/releases/download/v__VERSION__/cyclonedx-cr-v__VERSION__-linux-x86_64"
+      sha256 "__SHA_LINUX_X86_64__"
+    end
+  end
+
+  def install
+    bin.install Dir["cyclonedx-cr-v__VERSION__-*"].first => "cyclonedx-cr"
+  end
+
+  test do
+    system "#{bin}/cyclonedx-cr", "-h"
+  end
+end

--- a/.github/workflows/publish-homebrew-tap.yml
+++ b/.github/workflows/publish-homebrew-tap.yml
@@ -1,29 +1,104 @@
 ---
 name: Homebrew tap Publish
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 1.3.0)"
+        required: true
+        type: string
+  workflow_run:
+    workflows: ["Build and Release Binaries"]
+    types: [completed]
+permissions:
+  contents: read
 jobs:
-  homebrew-releaser:
+  publish-formula:
+    name: Publish prebuilt formula to tap
+    # Run after a release-triggered binary build succeeds, or on manual
+    # dispatch. The prebuilt formula needs the release binaries to exist first.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
     runs-on: ubuntu-latest
-    name: homebrew-releaser
     steps:
-      - name: Release cyclonedx-cr to Homebrew tap
-        uses: Justintime50/homebrew-releaser@v3
+      - name: Checkout source (formula template)
+        uses: actions/checkout@v6
         with:
-          homebrew_owner: hahwul
-          homebrew_tap: homebrew-cyclonedx-cr
-          formula_folder: Formula
-          github_token: ${{ secrets.PUBLISH_TOKEN }}
-          commit_owner: hahwul
-          commit_email: hahwul@gmail.com
-          depends_on: |
-            "crystal"
-          install: |
-            system "shards install"
-            system "shards build --release --no-debug --production"
-            bin.install "bin/cyclonedx-cr"
-          test: system "{bin}/cyclonedx-cr", "-v"
-          update_readme_table: false
-          skip_commit: false
-          debug: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.event.workflow_run.head_branch }}
+
+      - name: Resolve version
+        id: ver
+        # Pass event data via env (never interpolate ${{ }} straight into the
+        # script body) so a crafted tag/branch name can't inject shell.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            RAW="$DISPATCH_VERSION"
+          else
+            RAW="$RUN_BRANCH"
+          fi
+          # Strip leading 'v' if present
+          VERSION="${RAW#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Download release binaries and compute checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          # Linux binaries are static musl; macOS binaries are self-contained.
+          for asset in osx-arm64 osx-x86_64 linux-arm64 linux-x86_64; do
+            gh release download "v$V" --repo hahwul/cyclonedx-cr \
+              --pattern "cyclonedx-cr-v$V-$asset" --output "cyclonedx-cr-v$V-$asset"
+          done
+          {
+            echo "SHA_OSX_ARM64=$(sha256sum "cyclonedx-cr-v$V-osx-arm64" | awk '{print $1}')"
+            echo "SHA_OSX_X86_64=$(sha256sum "cyclonedx-cr-v$V-osx-x86_64" | awk '{print $1}')"
+            echo "SHA_LINUX_ARM64=$(sha256sum "cyclonedx-cr-v$V-linux-arm64" | awk '{print $1}')"
+            echo "SHA_LINUX_X86_64=$(sha256sum "cyclonedx-cr-v$V-linux-x86_64" | awk '{print $1}')"
+          } >> "$GITHUB_ENV"
+
+      - name: Render formula
+        env:
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          mkdir -p out
+          sed \
+            -e "s|__VERSION__|$V|g" \
+            -e "s|__SHA_OSX_ARM64__|$SHA_OSX_ARM64|g" \
+            -e "s|__SHA_OSX_X86_64__|$SHA_OSX_X86_64|g" \
+            -e "s|__SHA_LINUX_ARM64__|$SHA_LINUX_ARM64|g" \
+            -e "s|__SHA_LINUX_X86_64__|$SHA_LINUX_X86_64|g" \
+            .github/homebrew/cyclonedx-cr.rb.tmpl > out/cyclonedx-cr.rb
+          echo "----- rendered formula -----"
+          cat out/cyclonedx-cr.rb
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v6
+        with:
+          repository: hahwul/homebrew-cyclonedx-cr
+          token: ${{ secrets.PUBLISH_TOKEN }}
+          path: tap
+
+      - name: Commit and push formula
+        env:
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          mkdir -p tap/Formula
+          cp out/cyclonedx-cr.rb tap/Formula/cyclonedx-cr.rb
+          cd tap
+          git config user.name "hahwul"
+          git config user.email "hahwul@gmail.com"
+          git add Formula/cyclonedx-cr.rb
+          if git diff --cached --quiet; then
+            echo "Formula unchanged; nothing to publish."
+            exit 0
+          fi
+          git commit -m "cyclonedx-cr $V"
+          git push

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,0 +1,93 @@
+---
+name: Build and Release Binaries
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+permissions:
+  contents: write
+jobs:
+  build:
+    name: Build Binaries
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: ubuntu-24.04-arm
+            platform: linux
+          - os: macos-latest
+            platform: macos
+          - os: macos-15-intel
+            platform: macos
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+      - name: Checkout source code
+        uses: actions/checkout@v6
+      - name: Install dependencies
+        run: shards install
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v5
+      - name: Set architecture environment variable
+        run: |
+          if [ "$RUNNER_ARCH" == "X64" ]; then
+            echo "ARCH=x86_64" >> $GITHUB_ENV
+          elif [ "$RUNNER_ARCH" == "ARM64" ]; then
+            echo "ARCH=arm64" >> $GITHUB_ENV
+          else
+            echo "ARCH=unknown" >> $GITHUB_ENV
+          fi
+      - if: matrix.platform == 'linux'
+        name: Build binary (Linux, static musl)
+        # Build a fully static musl binary so the release artifact is
+        # self-contained. cyclonedx-cr binds libyaml (yaml) and libxml2 (xml);
+        # libxml2 in turn needs liblzma (xz) and zlib, so pull the matching
+        # -static archives.
+        run: |
+          mkdir -p build
+          docker run --rm -v "$(pwd)":/cyclonedx-cr -w /cyclonedx-cr --entrypoint="" \
+            crystallang/crystal:1.20.0-alpine sh -c "
+              apk add --no-cache yaml-dev yaml-static libxml2-dev libxml2-static xz-dev xz-static zlib-dev zlib-static git curl &&
+              shards install --release --no-debug --production &&
+              mkdir -p build &&
+              crystal build src/main.cr \
+                -o build/cyclonedx-cr-${GITHUB_REF_SLUG}-linux-${ARCH} \
+                --release --no-debug --static
+            "
+      - if: matrix.platform == 'macos'
+        name: Build binary (macOS)
+        run: |
+          mkdir -p build
+          BIN="build/cyclonedx-cr-${GITHUB_REF_SLUG}-osx-${ARCH}"
+          crystal build src/main.cr \
+            -o "$BIN" \
+            --no-debug --release
+          echo "== otool -L $BIN ==" && otool -L "$BIN"
+          # The Homebrew formula declares NO dependencies: cyclonedx-cr links
+          # only system libraries (system libxml2) plus statically linked
+          # Crystal runtime libs and libyaml. Fail the release if any Homebrew
+          # dylib sneaks in, which would break a clean-machine `brew install`.
+          EXTRA="$(otool -L "$BIN" \
+            | grep -oE '/(opt/homebrew|usr/local)/(opt|Cellar)/[^/]+' \
+            | sort -u || true)"
+          if [ -n "$EXTRA" ]; then
+            echo "::error::unexpected Homebrew dynamic deps (formula declares none):"
+            echo "$EXTRA"; exit 1
+          fi
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: build-${{ matrix.os }}-${{ env.ARCH }}
+          path: build
+      - if: startsWith(github.ref, 'refs/tags/')
+        name: Upload to GitHub Releases
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
+          file: build/*


### PR DESCRIPTION
## What
`brew install hahwul/cyclonedx-cr/cyclonedx-cr` currently **compiles from source** (tap formula from `Justintime50/homebrew-releaser`). This switches the tap to a **prebuilt-binary** formula, mirroring [hwaro](https://github.com/hahwul/hwaro). cyclonedx-cr had no binary-release workflow, so one is added.

## How it works
1. **new** `release-binary.yml` builds 4 prebuilt binaries (`cyclonedx-cr-v<ver>-{osx,linux}-{arm64,x86_64}`) → GitHub Release.
2. `publish-homebrew-tap.yml` (now a render+push job) downloads them, computes `sha256`, renders `.github/homebrew/cyclonedx-cr.rb.tmpl`, and commits `Formula/cyclonedx-cr.rb` to `hahwul/homebrew-cyclonedx-cr`.

## Changes
- add `.github/workflows/release-binary.yml` — 4 platforms incl. `macos-15-intel`. Linux = static musl (alpine, with `libxml2`/`lzma`/`zlib` `-static` archives for the `xml` binding); macOS links only system libs (system `libxml2`) + static Crystal runtime/`libyaml`, with an `otool` guard.
- add `.github/homebrew/cyclonedx-cr.rb.tmpl` — **no `depends_on`** (no TLS; uses `json`/`xml`/`yaml` only); test `cyclonedx-cr -h`.
- rewrite `publish-homebrew-tap.yml` → render template + push to tap (uses the existing `PUBLISH_TOKEN`).

## Notes
- Takes effect on the **next tagged release**, which also validates the static-musl Linux build (the `-static` apk set may need a one-line tweak on first run).
- The GitHub Action wrapper and GHCR image are untouched. Verified locally: `brew style` clean; formula renders to valid Ruby.
