### PR TITLE
fix(action): prevent GitHub Action output injection via fixed GITHUB_OUTPUT delimiter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - shard.lock
       - Dockerfile
       - "**/*.cr"
+      - github-action/**
   push:
     branches: [main]
   workflow_dispatch:
@@ -34,6 +35,9 @@ jobs:
         run: shards build
       - name: Run tests
         run: crystal spec
+      - name: GitHub Action entrypoint output-injection test (issue #70)
+        if: matrix.crystal == 'latest'
+        run: ./github-action/test-entrypoint.sh
   build-docker:
     runs-on: ubuntu-latest
     strategy:

--- a/github-action/entrypoint.sh
+++ b/github-action/entrypoint.sh
@@ -55,17 +55,45 @@ if [ ! -f "$OUTPUT_FILE" ]; then
     exit 1
 fi
 
+# Emits a random hex token suitable for a unique GitHub Actions heredoc
+# delimiter. Prefers the kernel UUID source (present on Linux runners without
+# any extra package), then /dev/urandom; the final fallback is non-random but
+# the caller's collision check still guarantees a correct delimiter.
+gen_delimiter() {
+    if [ -r /proc/sys/kernel/random/uuid ]; then
+        printf 'cdx_%s' "$(tr -d '-' < /proc/sys/kernel/random/uuid)"
+    elif [ -r /dev/urandom ]; then
+        printf 'cdx_%s' "$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+    else
+        printf 'cdx_%s_%s' "$$" "$(date +%s 2>/dev/null || echo 0)"
+    fi
+}
+
 # Set GitHub Action outputs
 if [ -n "$GITHUB_OUTPUT" ]; then
     if [ "$OUTPUT_TO_FILE" = "true" ]; then
         echo "sbom_file=$OUTPUT_FILE" >> "$GITHUB_OUTPUT"
         echo "Generated SBOM file: $OUTPUT_FILE"
     else
-        # Use heredoc for multiline output to avoid delimiter issues
+        # Emit multiline SBOM content with a RANDOM heredoc delimiter. A fixed
+        # delimiter (the old `EOF`) is unsafe: GitHub ends the value at the
+        # first line that equals the delimiter, so attacker-controlled SBOM
+        # content -- e.g. a multiline dependency name that yields a bare `EOF`
+        # line in CSV output -- could terminate `sbom_content` early and inject
+        # arbitrary additional step outputs. The delimiter is re-rolled until it
+        # does not appear as a whole line in the content. See issue #70.
+        delimiter=$(gen_delimiter)
+        while grep -qxF -- "$delimiter" "$OUTPUT_FILE"; do
+            delimiter=$(gen_delimiter)
+        done
         {
-            echo "sbom_content<<EOF"
+            printf 'sbom_content<<%s\n' "$delimiter"
             cat "$OUTPUT_FILE"
-            echo "EOF"
+            # Guarantee the closing delimiter lands on its own line even when the
+            # content has no trailing newline (e.g. JSON output), otherwise the
+            # delimiter would be glued to the last content line and never match.
+            [ -n "$(tail -c1 "$OUTPUT_FILE")" ] && printf '\n'
+            printf '%s\n' "$delimiter"
         } >> "$GITHUB_OUTPUT"
         echo "Generated SBOM content (captured to output)"
     fi

--- a/github-action/test-entrypoint.sh
+++ b/github-action/test-entrypoint.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# Regression test for issue #70: GitHub Action output injection via a fixed
+# GITHUB_OUTPUT heredoc delimiter.
+#
+# It crafts a shard.lock whose dependency name contains newlines forming a bare
+# "EOF" line (the old fixed delimiter) plus an "injected=pwned" line, runs the
+# real entrypoint in each output format with no output_file, and asserts that:
+#   1. no step output is created outside the sbom_content heredoc value
+#      (i.e. the malicious content cannot inject step outputs), and
+#   2. the heredoc is well-formed (a closing delimiter line exists), so the
+#      value is not silently truncated or left unterminated.
+#
+# Run from anywhere after `shards build`:  ./github-action/test-entrypoint.sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+
+BIN_DIR="$REPO_ROOT/bin"
+if [ ! -x "$BIN_DIR/cyclonedx-cr" ]; then
+    echo "FAIL: $BIN_DIR/cyclonedx-cr not built (run 'shards build' first)" >&2
+    exit 1
+fi
+PATH="$BIN_DIR:$PATH"
+export PATH
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/shard.yml" <<'YML'
+name: victim
+version: 1.0.0
+YML
+
+# The dependency NAME (a YAML key) carries embedded newlines: a bare "EOF" line
+# and an "injected=pwned" line an attacker hopes to surface as a step output.
+printf 'version: 2.0\nshards:\n  "evil\\nEOF\\ninjected=pwned\\ntail":\n    github: a/b\n    version: 9.9.9\n' > "$WORK/shard.lock"
+
+# Counts step outputs declared OUTSIDE any heredoc value. POSIX awk only
+# (mawk-compatible: no gawk 3-arg match / gensub).
+count_injected() {
+    awk '
+        # Heredoc opener: key<<DELIM. Only recognised when NOT already inside a
+        # heredoc -- once inside, every line is content until the delimiter,
+        # exactly as the GitHub command-file parser behaves.
+        !inhd && /^[A-Za-z_][A-Za-z0-9_-]*<<.+$/ {
+            i = index($0, "<<")
+            delim = substr($0, i + 2)
+            inhd = 1
+            next
+        }
+        inhd && $0 == delim { inhd = 0; closed = 1; next }
+        # A key=value line outside a heredoc is a (possibly injected) output.
+        !inhd && /^[A-Za-z_][A-Za-z0-9_-]*=/ { injected++ }
+        END {
+            # closed must be 1 (heredoc terminated) and injected must be 0.
+            print (injected + 0) " " (closed + 0)
+        }
+    ' "$1"
+}
+
+rc=0
+for fmt in json xml csv; do
+    out="$WORK/gh_output.$fmt"
+    : > "$out"
+    GITHUB_OUTPUT="$out" sh "$SCRIPT_DIR/entrypoint.sh" \
+        "$WORK/shard.yml" "$WORK/shard.lock" "" 1.6 "$fmt" >/dev/null
+
+    set -- $(count_injected "$out")
+    injected=$1
+    closed=$2
+
+    if [ "$injected" != "0" ]; then
+        echo "FAIL [$fmt]: $injected step output(s) injected outside sbom_content" >&2
+        rc=1
+    elif [ "$closed" != "1" ]; then
+        echo "FAIL [$fmt]: sbom_content heredoc was not properly closed" >&2
+        rc=1
+    else
+        echo "PASS [$fmt]: no injection; heredoc well-formed"
+    fi
+done
+
+exit "$rc"


### PR DESCRIPTION
Fixes #70.

## Problem
`github-action/entrypoint.sh` wrote `sbom_content` to `$GITHUB_OUTPUT` with a **fixed** heredoc delimiter:

```sh
echo "sbom_content<<EOF"
cat "$OUTPUT_FILE"
echo "EOF"
```

GitHub ends a heredoc value at the first line that equals the delimiter. The SBOM content is derived from repository-controlled files, so attacker-controlled multiline data can contain a bare `EOF` line that terminates `sbom_content` early and **injects arbitrary additional step outputs**.

**Reachable** with `output_format: csv` + no `output_file`: a `shard.lock` dependency name is a YAML key that can embed newlines; CSV quoting preserves them, so a crafted name produces a physical line `EOF` followed by e.g. `injected=pwned`.

Reproduced (before fix): a dep named `"evil\nEOF\ninjected=pwned\ntail"` produced a real injected `injected=pwned` step output.

## Fix
- **Random per-invocation delimiter** `cdx_<uuid>` (from `/proc/sys/kernel/random/uuid`, falling back to `/dev/urandom`), **re-rolled until it does not appear as a whole line** in the content (`grep -qxF`). The attacker can no longer predict or match the delimiter.
- **Closing delimiter forced onto its own line** even when content has no trailing newline. This also fixes a latent correctness bug: the **default JSON** output has no trailing newline, so the old code glued `EOF` onto the last content line and never properly closed the heredoc.

## Tests
- New `github-action/test-entrypoint.sh` — POSIX (mawk/dash-compatible) regression test: crafts the malicious `shard.lock`, runs the **real** entrypoint in json/xml/csv, asserts (a) no step output injected outside `sbom_content`, (b) heredoc well-formed.
- Wired into CI (`crystal: latest`); added `github-action/**` to the CI path filter so action changes are covered.
- Verified locally: test **fails** against the old entrypoint, **passes** against the fix (negative control: old → 1 injected; new → 0 injected, properly closed). Happy path (both output modes) unchanged; `sbom_content` still parses as valid CycloneDX.